### PR TITLE
Fix memory bounds checking and I/O side effects in emulator

### DIFF
--- a/M6502.cpp
+++ b/M6502.cpp
@@ -616,7 +616,8 @@ memory->memWrite((quint16)(0x100 + stackPointer), accumulator);
 
 void M6502::PHP(void)
 {
- memory->memWrite((quint16)(0x100 + stackPointer), statusRegister);
+    // 6502 spec: PHP always pushes with bits 4 (B) and 5 (unused) set
+    memory->memWrite((quint16)(0x100 + stackPointer), statusRegister | B | 0x20);
     stackPointer--;
     cycles++;
 }
@@ -1856,12 +1857,15 @@ void M6502::setNMI(void)
 
 void M6502::step(void)
 {
+    cycles = 0;
     if (!(statusRegister & I) && IRQ)
         handleIRQ();
     if (NMI)
         handleNMI();
-    
+
+    int irqCycles = cycles;
     executeOpcode();
+    cycles += irqCycles;
 }
 
 void M6502::run(int maxCycles)
@@ -1888,11 +1892,6 @@ void M6502::start(void)
 void M6502::stop(void)
 {
     running = 0;
-}
-
-void M6502::setDisplayCallback(void (*callback)(char))
-{
-    displayCallback = callback;
 }
 
 /*

--- a/M6502.h
+++ b/M6502.h
@@ -59,13 +59,6 @@ public:
     quint8 getStackPointer(void) const { return stackPointer; }
     quint16 getProgramCounter(void) const { return programCounter; }
     
-    // Callback pour l'affichage (Apple 1 utilise 0xD012)
-    void setDisplayCallback(void (*callback)(char));
-    
-private:
-    void (*displayCallback)(char) = nullptr;
-
-
 private :
 
     Memory *memory;

--- a/MainWindow_ImGui.cpp
+++ b/MainWindow_ImGui.cpp
@@ -30,9 +30,8 @@ void MainWindow_ImGui::createPom1()
     screen = std::make_unique<Screen_ImGui>();
     memoryViewer = std::make_unique<MemoryViewer_ImGui>(memory.get());
     
-    // Connecter l'affichage
+    // Connecter l'affichage (display goes through Memory's I/O at 0xD012)
     memory->setDisplayCallback(Screen_ImGui::displayCallback);
-    cpu->setDisplayCallback(Screen_ImGui::displayCallback);
 
     // Initialiser le CPU au WOZ Monitor
     cpu->hardReset();
@@ -483,9 +482,9 @@ void MainWindow_ImGui::renderDebugDialog()
         // Désassemblage de l'instruction courante
         if (ImGui::CollapsingHeader("Instruction courante", ImGuiTreeNodeFlags_DefaultOpen)) {
             quint16 pc = cpu->getProgramCounter();
-            quint8 opcode = memory->memRead(pc);
-            quint8 operand1 = memory->memRead(pc + 1);
-            quint8 operand2 = memory->memRead(pc + 2);
+            quint8 opcode = memory->memPeek(pc);
+            quint8 operand1 = memory->memPeek(pc + 1);
+            quint8 operand2 = memory->memPeek(pc + 2);
             
             ImGui::Text("PC: 0x%04X", pc);
             ImGui::Text("Opcode: 0x%02X", opcode);
@@ -504,7 +503,7 @@ void MainWindow_ImGui::renderDebugDialog()
             ImGui::Columns(2, "StackColumns");
             for (int i = 0; i < 8; i++) {
                 quint16 addr = 0x0100 + ((sp + i + 1) & 0xFF);
-                quint8 value = memory->memRead(addr);
+                quint8 value = memory->memPeek(addr);
                 ImGui::Text("0x01%02X:", (sp + i + 1) & 0xFF);
                 ImGui::NextColumn();
                 ImGui::Text("0x%02X", value);
@@ -527,7 +526,7 @@ void MainWindow_ImGui::renderDebugDialog()
                 std::stringstream ss;
                 ss << "PC: 0x" << std::hex << std::uppercase << currentPC 
                    << " - Opcode: 0x" << std::setfill('0') << std::setw(2) 
-                   << static_cast<int>(memory->memRead(currentPC));
+                   << static_cast<int>(memory->memPeek(currentPC));
                 debugLog.push_back(ss.str());
                 
                 // Garder seulement les 50 dernières entrées
@@ -817,9 +816,9 @@ void MainWindow_ImGui::reset()
 
 void MainWindow_ImGui::hardReset()
 {
-    cpu->hardReset();
     memory->resetMemory();
     memory->initMemory();
+    cpu->hardReset();  // Must be after initMemory so reset vector is read from fresh ROMs
     screen->clear();
     setStatusMessage("Reset matériel effectué - Mémoire réinitialisée", 2.0f);
 }
@@ -907,12 +906,10 @@ void MainWindow_ImGui::handleKeyboardInput()
 
     for (int i = 0; i < io.InputQueueCharacters.Size; i++) {
         ImWchar c = io.InputQueueCharacters[i];
+        // Only process printable ASCII chars here; control keys (Enter, Backspace, Escape)
+        // are handled separately via IsKeyPressed below to avoid double input
         if (c >= 32 && c <= 126) {
             memory->setKeyPressed((char)c);
-        } else if (c == '\r' || c == '\n') {
-            memory->setKeyPressed('\r');
-        } else if (c == '\b' || c == 127) {
-            memory->setKeyPressed('\b');
         }
     }
 

--- a/Memory.cpp
+++ b/Memory.cpp
@@ -103,10 +103,12 @@ int Memory::loadBasic(void)
     file.read(fileContent.data(), fileSize);
     file.close();
     
-    for (size_t i = 0; i < fileContent.size(); ++i) {
+    size_t maxSize = 0x10000 - 0xE000; // Max bytes that fit from 0xE000
+    size_t loadSize = std::min(fileContent.size(), maxSize);
+    for (size_t i = 0; i < loadSize; ++i) {
         mem[i+0xE000] = (quint8)fileContent[i];
     }
-    cout <<"Basic Loaded to 0xE000 : " << fileContent.size() << " Bytes" << endl;
+    cout <<"Basic Loaded to 0xE000 : " << loadSize << " Bytes" << endl;
     return 0;
 }
 
@@ -140,10 +142,12 @@ int Memory::loadKrusader(void)
     file.read(fileContent.data(), fileSize);
     file.close();
     
-    for (size_t i = 0; i < fileContent.size(); ++i) {
+    size_t maxSize = 0x10000 - 0xA000; // Max bytes that fit from 0xA000
+    size_t loadSize = std::min(fileContent.size(), maxSize);
+    for (size_t i = 0; i < loadSize; ++i) {
         mem[i+0xA000] = (quint8)fileContent[i];
     }
-    cout <<"Krusader-1.3 Loaded to 0xA000 : " << fileContent.size() << " Bytes" << endl;
+    cout <<"Krusader-1.3 Loaded to 0xA000 : " << loadSize << " Bytes" << endl;
     return 0;
 }
 
@@ -175,10 +179,12 @@ int Memory::loadWozMonitor(void)
     file.read(fileContent.data(), fileSize);
     file.close();
     
-    for (size_t i = 0; i < fileContent.size(); ++i) {
+    size_t maxSize = 0x10000 - 0xFF00; // Max bytes that fit from 0xFF00
+    size_t loadSize = std::min(fileContent.size(), maxSize);
+    for (size_t i = 0; i < loadSize; ++i) {
         mem[i+0xFF00] = (quint8)fileContent[i];
     }
-    cout <<"WozMonitor Loaded to 0xFF00 : " << fileContent.size() << " Bytes" << endl;
+    cout <<"WozMonitor Loaded to 0xFF00 : " << loadSize << " Bytes" << endl;
     return 0;
 }
 
@@ -237,8 +243,8 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress)
         cleaned += line;
     }
 
-    quint16 currentAddr = 0;
-    quint16 runAddr = 0;
+    int currentAddr = 0;
+    int runAddr = 0;
     bool firstAddr = true;
     bool hasRunAddr = false;
     int totalBytes = 0;
@@ -305,8 +311,14 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress)
             }
 
             // Sinon c'est des données hex — parser par paires
-            for (size_t j = 0; j + 1 < hexStr.size(); j += 2) {
-                quint8 val = (hexVal(hexStr[j]) << 4) | hexVal(hexStr[j + 1]);
+            // Odd trailing digit is treated as low nibble (e.g. "F" -> 0x0F)
+            for (size_t j = 0; j < hexStr.size(); j += 2) {
+                quint8 val;
+                if (j + 1 < hexStr.size()) {
+                    val = (hexVal(hexStr[j]) << 4) | hexVal(hexStr[j + 1]);
+                } else {
+                    val = hexVal(hexStr[j]);
+                }
                 if (currentAddr < 0x10000) {
                     mem[currentAddr++] = val;
                     totalBytes++;
@@ -328,6 +340,11 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress)
     return firstAddr && !hasRunAddr ? 1 : 0;
 }
 
+quint8 Memory::memPeek(quint16 address) const
+{
+    return mem[address];
+}
+
 quint8 Memory::memRead(quint16 address)
 {
     // Apple 1 Clavier : lecture de 0xD010 (KBD) et 0xD011 (KBDCR)
@@ -339,7 +356,6 @@ quint8 Memory::memRead(quint16 address)
         // Lire 0xD010 efface le strobe (PIA 6821 behavior)
         quint8 result = keyReady ? (lastKey | 0x80) : 0x00;
         keyReady = false;
-        keyStickyCounter = 0;
         // Charger la touche suivante du buffer si disponible
         if (!keyBuffer.empty()) {
             lastKey = keyBuffer.front();

--- a/Memory.h
+++ b/Memory.h
@@ -50,6 +50,7 @@ public:
 
 
     quint8 memRead(quint16 address);
+    quint8 memPeek(quint16 address) const; // Read without I/O side effects
     //quint8 memReadAbsolute(quint16 adr);
     void memWrite(quint16 address, quint8 value);
 
@@ -71,7 +72,6 @@ private:
     // Clavier Apple 1 (0xD010 = KBD, 0xD011 = KBDCR)
     char lastKey = 0;
     bool keyReady = false;
-    int keyStickyCounter = 0;
     queue<char> keyBuffer;
 
     // Display Apple 1 (0xD012) - délai d'affichage

--- a/MemoryViewer_ImGui.cpp
+++ b/MemoryViewer_ImGui.cpp
@@ -143,7 +143,7 @@ void MemoryViewer_ImGui::renderHexView()
             int currentAddr = address + col;
             if (currentAddr > 0xFFFF) break;
             
-            quint8 value = memory->memRead(currentAddr);
+            quint8 value = memory->memPeek(currentAddr);
 
             ImGui::SameLine();
 
@@ -257,7 +257,7 @@ void MemoryViewer_ImGui::searchMemory()
     int searchStart = (searchAddress >= 0) ? searchAddress + 1 : startAddress;
     
     for (int addr = searchStart; addr <= 0xFFFF; ++addr) {
-        if (memory->memRead(addr) == searchValue) {
+        if (memory->memPeek(addr) == searchValue) {
             searchAddress = addr;
             return;
         }
@@ -265,7 +265,7 @@ void MemoryViewer_ImGui::searchMemory()
     
     // Si pas trouvé, rechercher depuis le début
     for (int addr = 0; addr < searchStart; ++addr) {
-        if (memory->memRead(addr) == searchValue) {
+        if (memory->memPeek(addr) == searchValue) {
             searchAddress = addr;
             return;
         }
@@ -303,7 +303,7 @@ void MemoryViewer_ImGui::renderEditPopup()
 
     if (ImGui::BeginPopupModal("Éditer Mémoire", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
         ImGui::Text("Adresse: %s", formatAddress(editAddress).c_str());
-        ImGui::Text("Valeur actuelle: 0x%02X (%d)", memory->memRead(editAddress), memory->memRead(editAddress));
+        ImGui::Text("Valeur actuelle: 0x%02X (%d)", memory->memPeek(editAddress), memory->memPeek(editAddress));
 
         ImGui::Spacing();
         ImGui::Text("Nouvelle valeur (hex):");
@@ -360,7 +360,7 @@ void MemoryViewer_ImGui::searchAsciiString()
     for (int addr = searchStart; addr <= 0xFFFF - searchLen; ++addr) {
         bool found = true;
         for (int i = 0; i < searchLen; ++i) {
-            if (memory->memRead(addr + i) != (quint8)searchBuffer[i]) {
+            if (memory->memPeek(addr + i) != (quint8)searchBuffer[i]) {
                 found = false;
                 break;
             }
@@ -375,7 +375,7 @@ void MemoryViewer_ImGui::searchAsciiString()
     for (int addr = 0; addr < searchStart && addr <= 0xFFFF - searchLen; ++addr) {
         bool found = true;
         for (int i = 0; i < searchLen; ++i) {
-            if (memory->memRead(addr + i) != (quint8)searchBuffer[i]) {
+            if (memory->memPeek(addr + i) != (quint8)searchBuffer[i]) {
                 found = false;
                 break;
             }

--- a/Screen_ImGui.cpp
+++ b/Screen_ImGui.cpp
@@ -123,6 +123,7 @@ void Screen_ImGui::writeChar(char c)
         if (cursorX >= SCREEN_WIDTH) newLine();
         screenBuffer[cursorY][cursorX] = c;
         cursorX++;
+        if (cursorX >= SCREEN_WIDTH) newLine();
     }
 }
 


### PR DESCRIPTION
## Summary
This PR addresses several critical issues in the Apple 1 emulator related to memory access bounds checking, I/O side effects, and CPU instruction handling.

## Key Changes

**Memory Loading Safety**
- Added bounds checking to `loadBasic()`, `loadKrusader()`, and `loadWozMonitor()` to prevent buffer overflows when loading ROM files
- Each loader now calculates the maximum available space at its target address and uses `std::min()` to limit the loaded size

**I/O Side Effects Separation**
- Introduced new `memPeek()` method for read-only memory access without triggering I/O side effects
- Replaced all debug/display reads with `memPeek()` to prevent unintended keyboard state changes during inspection
- Removed `keyStickyCounter` variable that was being reset during debug reads

**CPU and Instruction Fixes**
- Fixed PHP (Push Processor Status) instruction to correctly set bits 4 (B flag) and 5 (unused) per 6502 specification
- Corrected cycle counting in `step()` method to properly accumulate IRQ/NMI handling cycles
- Removed unused `setDisplayCallback()` method from CPU (display I/O is handled through Memory at 0xD012)

**Hex Dump Parser Improvement**
- Fixed handling of odd-length hex strings by treating trailing single digits as low nibbles (e.g., "F" → 0x0F)
- Changed loop condition from `j + 1 < hexStr.size()` to `j < hexStr.size()` with conditional pair handling

**Initialization Order**
- Reordered `hardReset()` to call `initMemory()` before `cpu->hardReset()` so the CPU reads the reset vector from freshly loaded ROMs

**Display and Input Handling**
- Fixed screen wrapping by adding newline check after cursor increment in `writeChar()`
- Improved keyboard input handling with clearer comments about control key separation
- Removed duplicate handling of Enter and Backspace keys in ImGui input queue

**Type Safety**
- Changed `currentAddr` and `runAddr` from `quint16` to `int` in hex dump loader for safer bounds checking

## Notable Implementation Details
- The new `memPeek()` method is marked `const` to enforce read-only semantics
- Display callback is now exclusively routed through Memory's I/O handling at address 0xD012
- Keyboard state is no longer corrupted by debug inspection operations

https://claude.ai/code/session_0186nXA3ebHbZ3C7wgPNkZPT