### PR TITLE
Fix 3 bugs: PLP B-flag masking, debug speed slider range, sticky std::hex

### DIFF
--- a/M6502.cpp
+++ b/M6502.cpp
@@ -651,7 +651,9 @@ accumulator = memory->memRead((quint16)(stackPointer + 0x100));
 void M6502::PLP(void)
 {
     stackPointer++;
-  statusRegister = memory->memRead((quint16)(stackPointer + 0x100));
+    // B flag (bit 4) doesn't exist as a physical register bit on the 6502;
+    // bit 5 is always 1.  PLP must ignore bit 4 and force bit 5.
+    statusRegister = (memory->memRead((quint16)(stackPointer + 0x100)) | 0x20) & ~B;
     cycles += 2;
 }
 
@@ -1836,10 +1838,10 @@ void M6502::hardReset(void)
     }
     
     quint16 resetVector = memReadAbsolute(0xFFFC);
-    std::cout << "hardReset: Lecture vecteur reset 0xFFFC = 0x" << std::hex << resetVector << std::endl;
+    std::cout << "hardReset: Lecture vecteur reset 0xFFFC = 0x" << std::hex << resetVector << std::dec << std::endl;
     programCounter = resetVector;
-    std::cout << "hardReset: PC initialisé à 0x" << std::hex << programCounter << " (devrait être 0xFF00)" << std::endl;
-    std::cout << "hardReset: SP=0x" << std::hex << (int)stackPointer << ", A=0x" << (int)accumulator << std::endl;
+    std::cout << "hardReset: PC initialisé à 0x" << std::hex << programCounter << std::dec << " (devrait être 0xFF00)" << std::endl;
+    std::cout << "hardReset: SP=0x" << std::hex << (int)stackPointer << ", A=0x" << (int)accumulator << std::dec << std::endl;
 }
 void M6502::softReset(void)
 {

--- a/MainWindow_ImGui.cpp
+++ b/MainWindow_ImGui.cpp
@@ -473,7 +473,7 @@ void MainWindow_ImGui::renderDebugDialog()
             
             ImGui::Spacing();
             ImGui::Text("Vitesse d'exécution:");
-            ImGui::SliderInt("##Speed", &executionSpeed, 1, 10000, "%d cycles/frame");
+            ImGui::SliderInt("##Speed", &executionSpeed, 1, 1000000, "%d cycles/frame");
             
             ImGui::Spacing();
             ImGui::Text("État: %s", cpuRunning ? "EN COURS" : "ARRÊTÉ");

--- a/Memory.cpp
+++ b/Memory.cpp
@@ -201,7 +201,7 @@ int Memory::loadBinary(const char* filename, quint16 startAddress)
     file.seekg(0, std::ios::beg);
 
     if (startAddress + fileSize > 0x10000) {
-        cout << "ERROR : File too large for address 0x" << std::hex << startAddress << endl;
+        cout << "ERROR : File too large for address 0x" << std::hex << startAddress << std::dec << endl;
         file.close();
         return 1;
     }


### PR DESCRIPTION
1. PLP now correctly masks bit 4 (B flag) and forces bit 5 to 1, matching
   real 6502 behavior where the B flag doesn't exist as a physical register
   bit. Previously, BRK→RTI sequences could leave B set in the status register.

2. Debug dialog speed slider range changed from 1-10000 to 1-1000000. The old
   max of 10000 was below all normal speed values (16667/33333/1000000),
   so touching the slider would clamp the CPU to an unusably slow speed.

3. Added std::dec after std::hex in console output paths to prevent sticky
   hex formatting from corrupting subsequent decimal output.

https://claude.ai/code/session_01SRn9Q3UVbrwQPyJz7rzrJe