### PR TITLE
Add validation for hex dump parsing and preset index bounds

### DIFF
--- a/Memory.cpp
+++ b/Memory.cpp
@@ -620,6 +620,7 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress, int* bytesL
     bool firstAddr = true;
     bool hasRunAddr = false;
     int totalBytes = 0;
+    int oddDigitsDropped = 0;
     size_t i = 0;
 
     auto isHex = [](char c) { return std::isxdigit((unsigned char)c); };
@@ -667,6 +668,7 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress, int* bytesL
                 // Handle merged data+run: e.g. "FFE2B3R" = data FF, run E2B3
                 if (hexStr.size() > 4) {
                     size_t dataLen = hexStr.size() - 4;
+                    if (dataLen % 2 != 0) oddDigitsDropped++;
                     for (size_t j = 0; j + 1 < dataLen; j += 2) {
                         quint8 val = (hexVal(hexStr[j]) << 4) | hexVal(hexStr[j + 1]);
                         if (currentAddr < 0x10000) {
@@ -686,6 +688,7 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress, int* bytesL
                 // Handle merged data+address: e.g. "ED0300:" = data ED, address 0300
                 if (hexStr.size() > 4) {
                     size_t dataLen = hexStr.size() - 4;
+                    if (dataLen % 2 != 0) oddDigitsDropped++;
                     for (size_t j = 0; j + 1 < dataLen; j += 2) {
                         quint8 val = (hexVal(hexStr[j]) << 4) | hexVal(hexStr[j + 1]);
                         if (currentAddr < 0x10000) {
@@ -704,7 +707,10 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress, int* bytesL
                 continue;
             }
 
-            // Data bytes — parse in pairs
+            // Data bytes — parse in pairs. A lone trailing nibble would
+            // otherwise be silently dropped, so track it for the summary
+            // warning below — masks real bugs in hand-edited dumps.
+            if (hexStr.size() % 2 != 0) oddDigitsDropped++;
             for (size_t j = 0; j + 1 < hexStr.size(); j += 2) {
                 quint8 val = (hexVal(hexStr[j]) << 4) | hexVal(hexStr[j + 1]);
                 if (currentAddr < 0x10000) {
@@ -734,6 +740,14 @@ int Memory::loadHexDump(const char* filename, quint16 &startAddress, int* bytesL
             << " (" << std::dec << totalBytes << " bytes starting at 0x"
             << std::hex << startAddress << ")";
         pom1::log().info("Mem", oss.str());
+    }
+    if (oddDigitsDropped > 0) {
+        std::ostringstream oss;
+        oss << "Hex dump " << std::filesystem::path(filename).filename().string()
+            << ": " << std::dec << oddDigitsDropped
+            << " odd-length hex run(s) detected — trailing nibble(s) dropped. "
+            << "Check the source for a truncated byte.";
+        pom1::log().warn("Mem", oss.str());
     }
     return firstAddr && !hasRunAddr ? 1 : 0;
 }

--- a/main_imgui.cpp
+++ b/main_imgui.cpp
@@ -158,6 +158,13 @@ int main(int argc, char* argv[])
             char* end = nullptr;
             long idx = strtol(val.c_str(), &end, 10);
             if (end != val.c_str() && *end == '\0') {
+                int presetCount = MainWindow_ImGui::getPresetCount();
+                if (idx < 0 || idx >= presetCount) {
+                    pom1::log().error("POM1", "Preset index " + val + " out of range [0, " +
+                                              std::to_string(presetCount - 1) +
+                                              "]. Use --list-presets to see available presets.");
+                    return 1;
+                }
                 requestedPreset = static_cast<int>(idx);
             } else {
                 // Match by name (case-insensitive substring)


### PR DESCRIPTION
## Summary
This PR improves error detection and validation in two areas: hex dump file parsing and command-line preset selection. It adds tracking of malformed hex data and validates preset indices before use.

## Key Changes

- **Hex dump parsing improvements:**
  - Added tracking of odd-length hex runs (trailing nibbles) that get silently dropped during parsing
  - Introduced `oddDigitsDropped` counter that increments when hex strings have odd lengths in three parsing paths: merged data+run, merged data+address, and regular data bytes
  - Added warning log message that reports the number of odd-length hex runs detected, helping users identify truncated bytes in hand-edited hex dumps

- **Preset index validation:**
  - Added bounds checking for preset indices provided via command-line arguments
  - Validates that the index is within the valid range `[0, presetCount - 1]`
  - Returns error code 1 and logs a helpful error message if the index is out of range, including the valid range and a suggestion to use `--list-presets`

## Implementation Details

The hex dump tracking is non-intrusive—it only counts problematic cases without changing the parsing logic itself. The warning is emitted at the end of the load operation, making it easy for users to spot data integrity issues in their hex dump files.

The preset validation happens early in the argument parsing flow, preventing invalid indices from being used and providing clear feedback to users about available presets.

https://claude.ai/code/session_01WRkH4AP7uA1f6zs5ry2deZ