### PR TITLE
Add C programming guide, apple1c library, and POM1 Bench C support

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,97 @@
+# 🍎 POM1 Quick Start — your first Apple 1 program in 5 minutes
+
+New to the Apple 1? Start here. No assembly, no toolchain — just the emulator and
+a few keystrokes. (Already built POM1? If not, see the [README](README.md)
+*Quick Start*.) When you boot, you land at the WOZ Monitor's bare `\` prompt —
+that's normal. Let's make it do something.
+
+---
+
+## Step 1 — Write your first program (BASIC, 30 seconds)
+
+The friendliest way in. **BASIC needs no toolchain and runs instantly.**
+
+1. Boot POM1 on **preset #1** (*Apple-1 with ACI & BASIC*) — the menu bar
+   *Presets* list, or it may already be selected.
+2. At the `\` prompt, type:  **`E000R`**  ↵   — this cold-starts **Integer BASIC**.
+   The prompt changes to `>`.
+3. Now type a program (BASIC numbers each line):
+
+   ```basic
+   10 PRINT "HELLO WORLD"
+   20 GOTO 10
+   RUN
+   ```
+
+4. It scrolls `HELLO WORLD` forever. Press **Ctrl-C** (or reset, `F5`) to stop.
+
+🎉 You just programmed a 1976 computer. Change the text, the line numbers, add
+`30 PRINT "FROM POM1"` — experiment.
+
+> **Run a shipped classic instead?** From `>` go back to `\` (reset), then
+> *File → Load Memory* → `software/Integer_basic/hamurabi.apl.txt`. Each listing
+> ends with `E2B3R`, so it re-enters BASIC with the program loaded — just type
+> `RUN`. (Cold-start once with `E000R` first if you just booted.)
+
+---
+
+## Step 2 — Read the WOZ Monitor prompt
+
+The `\` prompt is the **WOZ Monitor**, Woz's 256-byte ROM. Its whole language:
+
+| You type | It means |
+|---|---|
+| `E000R`        | **R**un the program at address `$E000` |
+| `0`            | examine one byte at `$0000` |
+| `0.20`         | examine the range `$0000`–`$0020` |
+| `300: A9 0F`   | deposit bytes `A9 0F` starting at `$0300` |
+
+Addresses are **hexadecimal** (`$0000`–`$FFFF`). That `xxxxR` = "run here" is how
+you launch almost everything in POM1.
+
+---
+
+## Step 3 — Step up to assembly or C (the POM1 Bench)
+
+Ready for real 6502 code? POM1 has a built-in editor — an Arduino-style sketch
+IDE that compiles and runs without leaving the window.
+
+1. **DevBench → POM1 Bench (sketch editor)…**
+2. Click **New** (the file icon). Pick:
+   - **Language:** *Assembly* or *C* — both fine to start.
+   - **Target:** **Apple-1 dual 4K/8K (text) — start here**.
+3. A `HELLO WORLD` starter appears. Click **Upload** (the ▶ arrow) — it
+   assembles/compiles and runs on the emulator. Watch the screen.
+4. Edit the message, Upload again. That's the whole loop.
+
+> The Bench needs the **cc65** toolchain for asm/C (it tells you how to install
+> it if missing). Prefer no toolchain at all? Pick the **Wozmon hex** target and
+> Upload — it loads raw bytes with no compiler.
+
+From here:
+- **Assembly** → [`dev/Programming_Apple1_ASM.md`](dev/Programming_Apple1_ASM.md)
+  (and the playbook [`dev/APPLE1DEV.md`](dev/APPLE1DEV.md)).
+- **C** → [`dev/Programming_Apple1_C.md`](dev/Programming_Apple1_C.md).
+- Browse 60+ ready-to-run programs in `software/` (*File → Load Memory*).
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **WOZ Monitor** | The `\`-prompt ROM you boot into. `xxxxR` runs code at `xxxx`. |
+| **Preset** | A one-click machine config (RAM + expansion cards). 14 of them; see the [README](README.md#%EF%B8%8F-machine-presets) table. |
+| **Integer BASIC** | Apple's 1976 BASIC at `$E000`. Cold-start `E000R`, warm re-entry `E2B3R`. Integers only. |
+| **Applesoft Lite** | Floats + strings BASIC (`$6000`, `6000R`) on the microSD/CFFA1 presets. No `HOME`/`VTAB` — scroll-text only. |
+| **Load Memory** | *File → Load Memory* — pastes a `.bin` or Woz-hex `.txt` into RAM. A `.txt` ending in `xxxxR` auto-runs. |
+| **Woz hex / `.txt`** | A program as `AAAA: BB BB …` hex lines — exactly what you'd type at the Monitor, loadable in one go. |
+| **bit 7 rule** | The Apple-1 keyboard/display use bit 7 as a "data valid" flag. Matters in asm; the libraries handle it for you. |
+| **cc65** | The C/assembler toolchain (`ca65`/`ld65`/`cl65`) the Bench shells out to. `sudo apt install cc65` etc. |
+| **POM1 Bench** | The in-app code editor (*DevBench* menu). Write asm/C, compile, run — desktop only. |
+
+---
+
+*Stuck at the `\` prompt and nothing happens? Type `E000R` for BASIC, or load a
+program and run its address. The Apple 1 does nothing until you tell it to — that
+was the 1976 experience.* Welcome aboard. 🍎

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Built with Dear ImGui & OpenGL — fast, lightweight, cross-platform.
 
 ## ⚡ 60-second tour
 
-Five things to try **right after first boot** (every preset boots into WOZ Monitor at `$FF00`):
+Five things to try **right after first boot** (every preset boots into WOZ Monitor at `$FF00`). New to the Apple 1? Follow the guided **[`QUICKSTART.md`](QUICKSTART.md)** — your first program in 5 minutes.
 
 ```
 0:F      ; Wozmon "examine" — read $0000 (PIA test)
 F000R    ; cold-start whatever ROM is currently mapped at $F000
 ```
 
-1. **Type a one-line BASIC program** → preset **#1**, paste-loads `software/basic/Hamurabi.apl.txt`, type `RUN`. Welcome to 1976.
-2. **Listen to a SID tune** → preset **#6** (A1-SID), pick `software/sid/Commando.bin` from *File → Load Memory*, type `280R`. C64 chiptune on Apple 1 hardware.
+1. **Write your first BASIC program** → preset **#1**, type `E000R` (cold-start Integer BASIC), then `10 PRINT "HELLO WORLD"` and `RUN`. Welcome to 1976.
+2. **Play the A1-SID piano** → preset **#6** (A1-SID), *File → Load Memory* → `software/SOUND SID/Claudio_PARMIGIANI_SID_PIANO_ORIG.txt`, type `C400R`, then press keys to play. Real SID synthesis on Apple 1 hardware.
 3. **Plug a TMS9918 cartridge** → preset **#7** (CodeTank), *File → P-LAB CodeTank Library* → `Codetank_GAME2.rom` → flip *upper jumper* → `4000R`. Mode-III Nyan Cat at 20 fps.
 4. **BBS over real TCP** → preset **#9** (Wi-Fi Modem), `0280R` to load ATmodem, then `ATDT bbs.fozztexx.com:23`. Browse a 2026-era BBS in WOZ Monitor.
 5. **Live debugging** → `F1` opens the memory viewer, `F7` single-steps the 6502, `F3` opens the BRK trace. Watch Microchess plan its move.
@@ -213,9 +213,11 @@ Per-cart menu sources under `dev/projects/tms9918_codetank_{menu,game3_menu,test
 | 🌌 **Mandelbrot** · 📊 **Cellular** · 🎨 **PasArt** | Fractal, 1D CA, parametric ASCII |
 </details>
 
-<details><summary><b>💻 BASIC programs</b> — load Enhanced BASIC first (<code>E000R</code>)</summary>
+<details><summary><b>💻 BASIC programs</b> (<code>software/Integer_basic/</code>) — cold-start Integer BASIC with <code>E000R</code></summary>
 
 🚀 Star Trek · 🃏 Blackjack · 🏛️ Hamurabi · 🌙 Lunar Lander Graphics · ⏱️ Stopwatch · 🔧 Resistor Calculator
+
+These are **Integer BASIC** listings (`software/Integer_basic/*.apl.txt`). Cold-start the interpreter once with `E000R`, then *File → Load Memory* → a `.apl.txt` (each ends with `E2B3R`, so it re-enters BASIC with the program intact), then type `RUN`. *Enhanced BASIC* (Lee Davison's) is a separate dev tool under `software/Apple-1 dev/`.
 </details>
 
 <details><summary><b>🛠️ Dev tools</b></summary>
@@ -353,12 +355,23 @@ Steve Jobs' October-1976 *Interface Age* hack: tee the SWTPC PR-40 40-column mat
 
 ## 🔧 Writing your own Apple 1 software
 
+**New here?** Start with **[`QUICKSTART.md`](QUICKSTART.md)** — your first program
+in 5 minutes (BASIC, then the Bench). The easiest authoring path is the in-app
+**POM1 Bench** (*DevBench → POM1 Bench*): an Arduino-style editor that assembles
+6502 asm or compiles C and runs it in one click, with a `HELLO WORLD` starter per
+target.
+
+For asm/C, install the **cc65** toolchain first: `sudo apt install cc65`
+(Debian/Ubuntu) · `sudo dnf install cc65` (Fedora) · `sudo pacman -S cc65` (Arch) ·
+`brew install cc65` (macOS) · <https://cc65.github.io/> (Windows/other).
+
 POM1 ships a complete cc65-based dev tree under [`dev/`](dev/):
 
 - [`dev/APPLE1DEV.md`](dev/APPLE1DEV.md) — agent-facing playbook (decision tree, I/O cheat sheet, deployment, gotchas, example index).
 - [`dev/Programming_Apple1_ASM.md`](dev/Programming_Apple1_ASM.md) — guide ASM (~790 lignes, FR) : 6502, cc65, HGR, TMS9918 (trilogies Sokoban + Connect 4).
+- [`dev/Programming_Apple1_C.md`](dev/Programming_Apple1_C.md) — C guide (cc65): one shared Apple-1 text base + the GEN2 HGR / TMS9918 graphics layers.
 - [`dev/projects/<name>/`](dev/projects/) — per-program README + Makefile + sources for everything POM1 ships.
-- [`dev/lib/`](dev/lib/) — reusable libraries (`apple1`, `m6502`, `tms9918`, `hgr`, `games/{chess,sokoban}`).
+- [`dev/lib/`](dev/lib/) — reusable libraries: **asm** (`apple1`, `m6502`, `tms9918`, `hgr`, `games/{chess,sokoban}`) + **C** (`apple1c` shared text/keyboard base, `gen2c` HGR runtime).
 - [`dev/cc65/*.cfg`](dev/cc65/) — shared linker configs.
 
 Quick build:

--- a/bench/CodeBench.cpp
+++ b/bench/CodeBench.cpp
@@ -165,6 +165,21 @@ void CodeBench::render(const char* title, bool* open)
         ImGui::SameLine(0, 6);
         if (circleBtn(ICON_FA_BOOK,      "##benchexamples", "Examples")) openExamplesPopup = true;
     }
+    // Load-address field — shown only for the raw-bytes target, the one place the
+    // entry address is the user's to set (asm/C take it from the linker cfg, hex
+    // from the dump text). Feeds rawAddr_ straight into verify()/upload().
+    if (targets[targetIndex_].wantsAddr) {
+        ImGui::SameLine(0, 16);
+        ImGui::SetCursorPosY(10.0f);
+        ImGui::AlignTextToFramePadding();
+        ImGui::PushStyleColor(ImGuiCol_Text, kWhite);
+        ImGui::TextUnformatted("@ $");
+        ImGui::PopStyleColor();
+        ImGui::SameLine(0, 4);
+        ImGui::SetNextItemWidth(60);
+        ImGui::InputText("##benchaddr", rawAddr_, sizeof(rawAddr_),
+                         ImGuiInputTextFlags_CharsHexadecimal | ImGuiInputTextFlags_CharsUppercase);
+    }
     if (host_->hasSerial()) {
         ImGui::SameLine(ImGui::GetWindowWidth() - 42);
         if (circleBtn(ICON_FA_MAGNIFYING_GLASS, "##benchserial", "Serial Monitor")) host_->openSerial();

--- a/dev/APPLE1DEV.md
+++ b/dev/APPLE1DEV.md
@@ -30,6 +30,14 @@ Agent-facing playbook for writing **new Apple 1 software** that runs under POM1.
 | 1976 SWTPC graphics | asm + GT-6144 | 64×96 mono | `dev/projects/gt6144_hello/gt6144.cfg` |
 | SID jingle | asm @ `$C800` regs | — | any |
 | Shell tool, file manager | asm + microSD shell | Text | `dev/cc65/apple1_4k.cfg` |
+| **Prefer C?** Text program | **C (cc65)** | Text 40×24 | `dev/cc65/apple1_c.cfg` + `dev/lib/apple1c/` |
+| **Prefer C?** Colour pixel art | C + GEN2 | HGR 280×192 | `dev/cc65/apple1_gen2_c.cfg` + `dev/lib/gen2c/` |
+| **Prefer C?** Sprite/tile game | C + TMS9918 | Graphics I/II | `apple1-videocard-lib/cc65/codetank_c.cfg` |
+
+> **Writing in C?** All three C targets share one card-neutral Apple-1
+> text/keyboard base (`dev/lib/apple1c/` — `woz_puts` / `woz_getkey` / `woz_mon`),
+> with the graphics runtime (`gen2c` for GEN2, the videocard-lib for TMS9918)
+> layered on top. Full guide: [`Programming_Apple1_C.md`](Programming_Apple1_C.md).
 
 **Base addresses** (stick to these for canonical `.txt` dumps):
 - `$0280` — ACI / microSD / Juke-Box / Applesoft programs (default `SAVE`/`LOAD` target, universal run address)
@@ -40,6 +48,16 @@ Agent-facing playbook for writing **new Apple 1 software** that runs under POM1.
 ---
 
 ## 2. Toolchain fast-path
+
+**Install cc65 first** (the `ca65` / `ld65` / `cl65` suite): `sudo apt install cc65`
+(Debian/Ubuntu) · `sudo dnf install cc65` (Fedora) · `sudo pacman -S cc65` (Arch) ·
+`brew install cc65` (macOS) · <https://cc65.github.io/> (Windows/other). Verify with
+`ca65 --version`.
+
+**Easiest authoring loop:** the in-app **POM1 Bench** (*DevBench → POM1 Bench*,
+desktop only) edits, assembles/compiles (asm **or** C) and runs in one click, with
+a `HELLO WORLD` starter per target — no Makefile needed. Copy `dev/projects/_template/`
+for a minimal asm or C starting point. The manual flow below is for batch/CI.
 
 Per-project Makefiles under `dev/projects/<name>/` already wire `ca65` + `ld65` + Woz-hex emit. Manual flow if you need it:
 
@@ -54,7 +72,7 @@ for i in range(0, len(data), 16):
 # In POM1: File > Load Memory → MyProg.txt → `280R` in Wozmon
 ```
 
-Compiled `.bin` / `.txt` Woz hex always land under `software/<dir>/` — that's POM1's runtime tree (preset auto-enable hooks are wired to `software/hgr/`, `software/tms9918/`, etc.).
+Compiled `.bin` / `.txt` Woz hex always land under `software/<dir>/` — that's POM1's runtime tree (preset auto-enable hooks are wired to `software/Graphic HGR/`, `software/Graphic TMS9918/`, etc.).
 
 All cc65 configs reserve **`$0000-$0022` ZP** (35 bytes); Wozmon + ACI claim the rest. `Memory::loadHexDump()` accepts canonical Wozmon dumps: `AAAA: HH HH …` lines, optional `:` separator, `R` suffix at EOF for auto-run, `T` prefix (turbo, no per-char delay), inline `//` `#` `;` comments stripped (otherwise mnemonic letters like `LDA`/`DEX` would parse as data).
 
@@ -107,7 +125,7 @@ No read-back, no main-RAM framebuffer (lives in 6× Intel 2102 SRAM). Plot `(x,y
 
 ## 5. Integer BASIC vs Applesoft Lite
 
-**Integer BASIC** (`$E000`, cold-start `E000R`): 16-bit signed (-32 767…+32 767), no floats, no strings beyond `PRINT`, ~16-deep `GOSUB`, no disk I/O (cassette or Juke-Box `&` only). Use when small + integer-only. Examples in `software/basic/` (load via File > Load Memory, then `E2B3R` to re-enter BASIC with the program intact).
+**Integer BASIC** (`$E000`, cold-start `E000R`): 16-bit signed (-32 767…+32 767), no floats, no strings beyond `PRINT`, ~16-deep `GOSUB`, no disk I/O (cassette or Juke-Box `&` only). Use when small + integer-only. Examples in `software/Integer_basic/` (cold-start once with `E000R`, then File > Load Memory a `.apl.txt` — each ends with `E2B3R` to re-enter BASIC with the program intact — then `RUN`).
 
 **Applesoft Lite** (`$6000` with microSD preset, cold-start `6000R`, warm `6003R`; or `$E000` with CFFA1):
 
@@ -210,7 +228,7 @@ Every byte `STA $D012` (with bit 7 set, normal display rules) also lands in PR-4
 
 ## 8. Deployment — four channels
 
-1. **Memory load** (default for dev iteration) — ship `.txt` Woz hex or `.bin`, user does **File > Load Memory** then `280R`. Auto-enables matching card if file lives under `software/hgr/`, `software/tms9918/`, `software/net/`|`/wifi/`, `software/a1io_rtc/`, `software/gt-6144/`, `sdcard/`. **`software/sid/` is intentionally NOT auto-enabled** (SID auto-plug desyncs the audio mixer across hardReset) — SID programs need a preset with `sid=true`.
+1. **Memory load** (default for dev iteration) — ship `.txt` Woz hex or `.bin`, user does **File > Load Memory** then `280R`. The Load dialog auto-enables the matching card from the file's folder: `software/Graphic HGR/` (GEN2), `software/SOUND SID/` (A1-SID), `software/Graphic TMS9918/` or `software/Apple-1_TMS_CC65/` (TMS9918), `software/Graphic gt-6144/` (GT-6144), `software/a1io_rtc/` (A1-IO & RTC), `software/NET/` (Wi-Fi modem), or `sdcard/` (microSD). Each match also pops the card's window.
 2. **microSD tagged file** — drop `NAME#TTAAAA` into `sdcard/` (optionally a sub-dir users `CD` into). Persists across sessions, also in WASM (preloaded MEMFS).
 3. **Juke-Box ROM bundle** — rebuild `roms/jukebox.rom` with your program baked, pick preset #11, type `BD00R`, choose from `&` prompt.
 4. **Cassette tape** — dump capture as `.aci`/`.wav`/`.mp3`/`.ogg`, drop in `cassettes/`. Add a line in `cassettes/tapeinfo.txt` (`MYPROG.ogg = 0280.04FF`) so the deck jaquette prints *"Type 0280.04FFR"*. Works in pulse mode (ACI plugged) and audio-stream mode (firmware-less).
@@ -314,7 +332,7 @@ Add a C++ test in `tests/`. Template: `tests/peripheral_bus_smoke_test.cpp` — 
 | Want… | Copy from |
 |---|---|
 | Text-mode game, ASCII tiles | `dev/projects/games_sokoban/Sokoban.asm` |
-| Text-mode BASIC | `software/basic/mini-startrek.apl.txt` (Integer) or write fresh Applesoft |
+| Text-mode BASIC | `software/Integer_basic/mini-startrek.apl.txt` (Integer) or write fresh Applesoft |
 | HGR pixel plotter | `dev/projects/hgr_mandelbrot/HGR_Mandelbrot.asm` + `dev/lib/hgr/hgr_tables.inc` |
 | HGR byte-aligned tiles | `dev/projects/hgr_sokoban/HGR_Sokoban.asm` (14 px wide) |
 | HGR sub-byte tiles (≠ 7 px) | `dev/projects/hgr_maze/HGR_Maze.asm` (4-px walls) |

--- a/dev/Programming_Apple1_ASM.md
+++ b/dev/Programming_Apple1_ASM.md
@@ -26,6 +26,15 @@ Ce document récapitule tout ce qu'il faut savoir pour programmer l'Apple 1 ému
 - **ld65** — linker, prend un `.cfg` pour placer segments et ZP
 - **python3** — génère le hex dump Woz Monitor à partir du binaire
 
+**Installer cc65** : `sudo apt install cc65` (Debian/Ubuntu) · `sudo dnf install cc65`
+(Fedora) · `sudo pacman -S cc65` (Arch) · `brew install cc65` (macOS) ·
+<https://cc65.github.io/> (Windows/autres). Vérifier avec `ca65 --version`.
+
+> **Le plus simple pour débuter** : le **POM1 Bench** intégré (*DevBench → POM1
+> Bench*, desktop) édite, assemble/compile (asm **ou** C) et lance en un clic, avec
+> un squelette `HELLO WORLD` par cible. Copie `dev/projects/_template/` pour un
+> point de départ minimal. En C → [`Programming_Apple1_C.md`](Programming_Apple1_C.md).
+
 ### Commandes standard
 
 Les sources vivent sous `dev/projects/<name>/` (chacun a son `Makefile`). Workflow manuel si besoin :
@@ -47,7 +56,7 @@ for i in range(0, len(data), 16):
 " > software/<dir>/MyGame.txt
 ```
 
-Le binaire compilé et son `.txt` Woz hex sont déposés sous `software/<dir>/` — c'est là que POM1 va les lire (les hooks d'auto-activation de carte sont câblés sur `software/hgr/`, `software/tms9918/`, etc.).
+Le binaire compilé et son `.txt` Woz hex sont déposés sous `software/<dir>/` — c'est là que POM1 va les lire (les hooks d'auto-activation de carte sont câblés sur `software/Graphic HGR/`, `software/Graphic TMS9918/`, etc.).
 
 ### Chargement dans POM1
 

--- a/dev/Programming_Apple1_C.md
+++ b/dev/Programming_Apple1_C.md
@@ -1,0 +1,185 @@
+# Programming the Apple 1 in C (cc65)
+
+The C counterpart to [`Programming_Apple1_ASM.md`](Programming_Apple1_ASM.md).
+You write C, the **cc65** cross-compiler (`cl65`) turns it into a 6502 binary,
+and POM1 runs it. No prior 6502 knowledge required — but the Apple 1 is a tiny
+machine, so a few rules below keep you out of trouble.
+
+**Fastest path:** *DevBench → POM1 Bench*, **New sketch → Language: C**, pick a
+machine, press **Upload**. The Bench wires the toolchain, the linker config and
+the libraries for you. This guide is for when you want to understand or build by
+hand.
+
+**Contents:** [Install](#1-install-cc65) · [Architecture](#2-architecture--one-text-base-two-graphics-layers) · [Your first program](#3-your-first-program) · [Text & keyboard](#4-text--keyboard-apple1c) · [GEN2 HGR](#5-gen2-hgr-colour-gen2c) · [TMS9918](#6-tms9918-sprites--colour) · [Memory budget](#7-memory-budget--the-1-gotcha) · [Gotchas](#8-gotchas)
+
+---
+
+## 1. Install cc65
+
+| OS | Command |
+|---|---|
+| Debian / Ubuntu | `sudo apt install cc65` |
+| Fedora | `sudo dnf install cc65` |
+| Arch | `sudo pacman -S cc65` |
+| macOS | `brew install cc65` |
+| Windows / other | <https://cc65.github.io/> — download, add `bin/` to `PATH` |
+
+Check it: `cl65 --version`. The POM1 Bench detects it automatically and tells you
+how to install it if it's missing.
+
+---
+
+## 2. Architecture — one text base, two graphics layers
+
+The key idea: **Apple-1 text + keyboard I/O is one shared library**, and each
+graphics card adds its own drawing layer on top. Learn the text API once; reuse
+it everywhere.
+
+```
+                 apple1c   (woz_puts / woz_getkey / woz_mon — the WOZ terminal)
+                /         \
+   GEN2 HGR (gen2c)        TMS9918 (apple1-videocard-lib: screen1 / tms9918)
+   280x192 colour          256x192, 32 sprites
+```
+
+| You want… | Include | Linker cfg | Runs at |
+|---|---|---|---|
+| **Plain text** (40×24 terminal) | `apple1io.h` | `dev/cc65/apple1_c.cfg` | `0300R` |
+| **GEN2 HGR colour** (+ text) | `gen2.h` (+ `apple1io.h`) | `dev/cc65/apple1_gen2_c.cfg` | `6000R` |
+| **TMS9918 sprites/colour** | `screen1.h` / `tms9918.h` | `apple1-videocard-lib/cc65/codetank_c.cfg` | `4000R` |
+
+Libraries:
+- `dev/lib/apple1c/` — the shared text/keyboard base ([README](lib/apple1c/README.md)).
+- `dev/lib/gen2c/` — GEN2 HGR runtime ([README](lib/gen2c/README.md)).
+- `dev/apple1-videocard-lib/` — Nino Porcino's TMS9918 runtime + demos.
+
+---
+
+## 3. Your first program
+
+```c
+#include "apple1io.h"
+
+void main(void) {
+    woz_puts((const unsigned char *)"\rHELLO WORLD\r");
+    woz_mon();                 /* return to the '\' Monitor prompt */
+}
+```
+
+Build and run (plain text):
+
+```bash
+cd dev/lib/apple1c
+cl65 -t none -Oirs -C ../../cc65/apple1_c.cfg -I . \
+     first.c apple1io.c apple1io_asm.s -o first.bin
+# In POM1: File > Load Memory > first.bin, then 0300R
+```
+
+Two non-obvious rules you just used:
+- **`void main(void)`**, not `int main()`. There's no OS to return a code to.
+- **No `<stdio.h>` / `printf`.** You print with `woz_puts` / `woz_putc`. (cc65's
+  full `printf` exists but pulls in a lot — keep it tiny.)
+
+---
+
+## 4. Text & keyboard (`apple1c`)
+
+`#include "apple1io.h"` — works on every machine.
+
+| Function | Effect |
+|---|---|
+| `woz_putc(c)` / `woz_puts(s)` | print a char / a string |
+| `woz_print_hex(b)` / `woz_print_hexword(w)` | print hex (no `printf` needed) |
+| `woz_mon()` | return to the WOZ Monitor |
+| `apple1_getkey()` | **block**, return `key & 0x7F` (uppercase only — the keyboard forces it) |
+| `apple1_readkey()` | `0` if no key, else the key (non-blocking — game loops) |
+| `apple1_iskeypressed()` | nonzero if a key is waiting |
+
+```c
+#include "apple1io.h"
+void main(void) {
+    unsigned char k;
+    woz_puts((const unsigned char *)"\rPRESS A KEY: ");
+    k = apple1_getkey();
+    woz_putc(k);
+    woz_mon();
+}
+```
+
+---
+
+## 5. GEN2 HGR colour (`gen2c`)
+
+`#include "gen2.h"` — 280×192 HIRES. Full API + gotchas: [lib/gen2c/README.md](lib/gen2c/README.md).
+
+```c
+#include "gen2.h"
+#include "apple1io.h"
+void main(void) {
+    gen2_hgr_init();                       /* graphics+hires+page1+full */
+    gen2_hgr_clear(0);                      /* black */
+    gen2_hgr_puts(42, 80, "SCORE");
+    gen2_hgr_putu(120, 80, 1234u);          /* a number */
+    for (;;) { }
+}
+```
+
+Build with `apple1_gen2_c.cfg`, run `6000R`. The two GEN2 rules: never *write*
+the `$C25x` soft switches, and always clear with `gen2_hgr_clear()` (a naïve
+16-bit loop is ~20× slower and blanks the screen).
+
+---
+
+## 6. TMS9918 sprites & colour
+
+Uses Nino Porcino's `apple1-videocard-lib` (`screen1.h`, `tms9918.h`,
+`screen2.h`). The Bench's **TMS9918 (C)** target builds a 16 KB CodeTank ROM and
+boots `4000R`. ~17 worked demos live in `dev/apple1-videocard-lib/demos/`
+(`hello_world`, `hello_screen1`, `tetris`, `rogue_c`, `sprite_animals`…).
+
+```c
+#include "tms9918.h"
+#include "screen1.h"
+void main(void) {
+    tms_init_regs(SCREEN1_TABLE);
+    tms_set_color(COLOR_CYAN);
+    screen1_prepare();
+    screen1_load_font();
+    screen1_puts((const unsigned char *)"HELLO TMS9918");
+    for (;;) { }
+}
+```
+
+---
+
+## 7. Memory budget — the #1 gotcha
+
+`apple1_c.cfg` (plain text) gives C only **`$0300-$0FFF` ≈ 2.75 KB** for
+code + data + the C stack. A few hundred bytes of global arrays and the linker
+overflows with a cryptic `ld65: Range error`. If you hit it:
+- move work into smaller functions / fewer globals, **or**
+- target **GEN2** (`apple1_gen2_c.cfg`, code at `$6000-$BEFF` ≈ 24 KB), **or**
+- use a bigger preset (the Multiplexing Fantasy, `pom1_fantasy.cfg`).
+
+| cfg | C code+data space | Notes |
+|---|---|---|
+| `apple1_c.cfg` | ~2.75 KB (`$0300-$0FFF`) | tight — small programs only |
+| `apple1_gen2_c.cfg` | ~24 KB (`$6000-$BEFF`) | roomy, above the HGR framebuffer |
+| `codetank_c.cfg` | 16 KB ROM image (`$4000`) | TMS9918, runs from ROM |
+
+---
+
+## 8. Gotchas
+
+| Gotcha | Fix |
+|---|---|
+| `int main()` misbehaves | use `void main(void)` |
+| `printf` not found / huge | use `woz_puts` / `woz_print_hex` / `gen2_hgr_putu` |
+| `ld65: Range error` on a small program | out of RAM — see §7, pick a roomier target |
+| GEN2 clear is slow + screen goes black for seconds | use `gen2_hgr_clear()`, not a 16-bit `for` loop |
+| GEN2 colours look wrong / switches don't stick | never `STA $C25x`; the macros *read* to toggle |
+| Keyboard compare fails for lowercase | the keyboard is **uppercase only** — compare `'A'`, never `'a'` |
+| C is missing in the web build | the cc65 Bench is **desktop-only**; compile on desktop |
+
+See also: [`APPLE1DEV.md`](APPLE1DEV.md) §1 decision tree, §3 I/O cheat sheet;
+[`Programming_Apple1_ASM.md`](Programming_Apple1_ASM.md) for the assembly route.

--- a/dev/lib/apple1c/README.md
+++ b/dev/lib/apple1c/README.md
@@ -1,0 +1,70 @@
+# apple1c/ — shared Apple-1 text + keyboard I/O for C (cc65)
+
+The **card-neutral base** every Apple-1 C program builds on. Output goes through
+the WOZ Monitor `ECHO` routine (`$FFEF`); input reads the PIA keyboard
+(`$D010`/`$D011`). It has **no dependency on any graphics card** — the two C
+graphics runtimes sit *on top* of this shared base:
+
+```
+                 apple1c  (this lib — woz_puts / woz_getkey / woz_mon)
+                /        \
+   GEN2 HGR (gen2c)       TMS9918 (apple1-videocard-lib: screen1 / tms9918)
+   Uncle Bernie           Antonino "Nino" Porcino
+```
+
+So a beginner learns **one** text/keyboard API and reuses it whether the program
+is plain text, GEN2 HGR colour, or TMS9918 sprites.
+
+## Files
+
+| File | Role |
+|---|---|
+| `apple1io.h`     | the public API (include this) |
+| `apple1io_asm.s` | asm shim — the four routines that call the WOZ ROM directly |
+| `apple1io.c`     | the small C layer on top (string + keyboard helpers) |
+
+> **Why `apple1io_asm.s`, not `apple1io.s`?** cc65 compiles `apple1io.c`
+> through an intermediate `apple1io.s`; a hand-written `apple1io.s` would be
+> overwritten. The `_asm.s` suffix mirrors Nino's `apple1.c` + `apple1_asm.s`.
+
+## API (`apple1io.h`)
+
+| Function | Effect |
+|---|---|
+| `woz_putc(c)`          | print one character via `ECHO` |
+| `woz_puts(s)`          | print a NUL-terminated string |
+| `woz_print_hex(b)`     | print a byte as two hex digits |
+| `woz_print_hexword(w)` | print a 16-bit word as four hex digits |
+| `woz_mon()`            | return control to the WOZ Monitor (`$FF1F`) |
+| `apple1_iskeypressed()`| nonzero (bit 7) if a key is waiting |
+| `apple1_getkey()`      | **block** until a key, return `key & 0x7F` |
+| `apple1_readkey()`     | `0` if no key, else `key & 0x7F` (no wait) |
+
+## Minimal program
+
+```c
+#include "apple1io.h"
+
+void main(void) {
+    woz_puts((const unsigned char *)"\rHELLO WORLD\r");
+    woz_mon();                       /* back to the '\' prompt */
+}
+```
+
+Build (plain text Apple-1, run `0300R`):
+
+```bash
+cl65 -t none -Oirs -C ../../cc65/apple1_c.cfg -I . \
+     hello.c apple1io.c apple1io_asm.s -o hello.bin
+```
+
+The **POM1 Bench** (*DevBench → POM1 Bench*) links this automatically for the
+*Apple-1 text (C)* and *GEN2 HGR (C)* targets, so on GEN2 you can draw HIRES
+**and** print to the terminal from the same program.
+
+## Credit
+
+Asm shim + keyboard helpers ported verbatim from
+[nippur72/apple1-videocard-lib](https://github.com/nippur72/apple1-videocard-lib)
+(Antonino "Nino" Porcino). Upstream license unspecified at fork time (2026) —
+preserve attribution.

--- a/dev/lib/apple1c/apple1io.c
+++ b/dev/lib/apple1c/apple1io.c
@@ -1,0 +1,31 @@
+/*
+ * apple1io.c — small C layer over the apple1io.s Wozmon shim. See apple1io.h.
+ *
+ * woz_putc / woz_print_hex / woz_mon / apple1_getkey live in apple1io_asm.s
+ * (they call the WOZ Monitor ROM directly); everything here is plain C on top.
+ */
+#include "apple1io.h"
+
+void woz_puts(const unsigned char *s) {
+    unsigned char c;
+    while ((c = *s++) != 0) {
+        woz_putc(c);
+    }
+}
+
+void woz_print_hexword(unsigned w) {
+    /* cc65 is little-endian: low byte first. Print high nibble-pair then low. */
+    woz_print_hex(*((unsigned char *)&w + 1));
+    woz_print_hex(*(unsigned char *)&w);
+}
+
+unsigned char apple1_iskeypressed(void) {
+    return (unsigned char)(*(volatile unsigned char *)KBD_CTRL & 0x80U);
+}
+
+unsigned char apple1_readkey(void) {
+    if ((*(volatile unsigned char *)KBD_CTRL & 0x80U) == 0) {
+        return 0;
+    }
+    return (unsigned char)(*(volatile unsigned char *)KBD_DATA & 0x7FU);
+}

--- a/dev/lib/apple1c/apple1io.h
+++ b/dev/lib/apple1c/apple1io.h
@@ -1,0 +1,38 @@
+/*
+ * apple1io.h — shared Apple-1 text + keyboard I/O for C (cc65), card-neutral.
+ *
+ * The common base every Apple-1 C program builds on, independent of any graphics
+ * card. Output goes through the WOZ Monitor ECHO routine ($FFEF); input reads the
+ * PIA keyboard ($D010/$D011). The two graphics C runtimes add their own layer ON
+ * TOP of this shared text base:
+ *   - TMS9918 (Antonino "Nino" Porcino) — apple1-videocard-lib screen1.h / tms9918.h
+ *   - GEN2 HGR (Uncle Bernie)           — dev/lib/gen2c/gen2.h
+ *
+ * Bit-7 rule (PIA 6821): the keyboard sets bit 7 as a data-valid strobe;
+ * apple1_getkey already masks the key down to 7 bits. woz_putc hands the byte to
+ * the ROM ECHO routine, which drives the display the same way Wozmon does.
+ *
+ * The asm shim (apple1io_asm.s) is ported verbatim from nippur72/apple1-videocard-lib
+ * (Antonino "Nino" Porcino) — preserve attribution. Upstream license unspecified.
+ */
+#ifndef APPLE1IO_H
+#define APPLE1IO_H
+
+#define WOZMON    0xFF1FU
+#define ECHO      0xFFEFU
+#define KBD_DATA  0xD010U
+#define KBD_CTRL  0xD011U
+
+/* ---- Output (via the WOZ Monitor ECHO routine at $FFEF) ---- */
+void woz_putc(unsigned char c);          /* print one character                 */
+void woz_puts(const unsigned char *s);   /* print a NUL-terminated string        */
+void woz_print_hex(unsigned char c);     /* print a byte as two hex digits       */
+void woz_print_hexword(unsigned w);      /* print a 16-bit word as four hex digits*/
+void woz_mon(void);                      /* return control to the WOZ Monitor    */
+
+/* ---- Keyboard (PIA $D010 data / $D011 control) ---- */
+unsigned char apple1_iskeypressed(void); /* nonzero (bit 7) if a key is waiting   */
+unsigned char apple1_getkey(void);       /* block until a key, return key & 0x7F  */
+unsigned char apple1_readkey(void);      /* 0 if no key, else key & 0x7F (no wait) */
+
+#endif /* APPLE1IO_H */

--- a/dev/lib/apple1c/apple1io_asm.s
+++ b/dev/lib/apple1c/apple1io_asm.s
@@ -1,0 +1,40 @@
+; ----------------------------------------------------------------------------
+; apple1io_asm.s — shared Apple-1 Wozmon text + keyboard hooks for cc65.
+;
+; Named *_asm.s (not apple1io.s) on purpose: cc65 compiles apple1io.c through an
+; intermediate apple1io.s, so a hand-written apple1io.s would be clobbered. This
+; mirrors nippur72/apple1-videocard-lib's apple1.c + apple1_asm.s split.
+;
+; Asm shim ported verbatim from nippur72/apple1-videocard-lib (Antonino "Nino"
+;   Porcino).  https://github.com/nippur72/apple1-videocard-lib
+; Upstream license unspecified at fork time (2026); preserve attribution.
+;
+; cc65 calling convention: an `unsigned char` argument arrives in A, an
+; `unsigned char` return value leaves in A — so each routine is a thin wrapper
+; around the WOZ Monitor ROM entry points.
+; ----------------------------------------------------------------------------
+.export _woz_putc, _woz_print_hex, _woz_mon, _apple1_getkey
+
+ECHO    = $FFEF
+PRBYTE  = $FFDC
+WOZMON  = $FF1F
+KEYCR   = $D011
+KEYDATA = $D010
+
+_woz_putc:
+        jsr     ECHO
+        rts
+
+_woz_print_hex:
+        jsr     PRBYTE
+        rts
+
+_woz_mon:
+        jmp     WOZMON
+
+_apple1_getkey:
+wait:   lda     KEYCR
+        bpl     wait
+        lda     KEYDATA
+        and     #$7F
+        rts

--- a/dev/lib/gen2c/README.md
+++ b/dev/lib/gen2c/README.md
@@ -1,0 +1,67 @@
+# gen2c/ — C runtime for Uncle Bernie's GEN2 HGR card (cc65)
+
+Minimal C over the GEN2 colour graphics card's **280×192 HIRES** framebuffer.
+Pairs with the shared [`apple1c`](../apple1c/) text base, so a GEN2 C program can
+draw HIRES *and* print to the WOZ terminal / read the keyboard.
+
+The GEN2 is the Apple II video subsystem on the Apple-1 bus. Mode is driven by
+**READ-ONLY** soft switches at `$C250-$C257` (a 1:1 port of Apple II
+`$C050-$C057`) — there is **no power-on default**, so a program must select the
+mode itself (`gen2_hgr_init()` does this).
+
+## API (`gen2.h`)
+
+| Function | Effect |
+|---|---|
+| `gen2_hgr_init()`            | graphics + HIRES + page 1 + full screen (call first) |
+| `gen2_hgr_clear(fill)`       | fill the `$2000-$3FFF` page (`0` = black) |
+| `gen2_hgr_plot(x, y)`        | set a white pixel, `x:0..279 y:0..191` |
+| `gen2_hgr_row(y)`            | base address of scanline `y` (Apple II interleave) |
+| `gen2_hgr_puts(x, y, s)`     | draw a white string (Beautiful Boot 8×8 font, 16×16 cells) |
+| `gen2_hgr_putu(x, y, value)` | draw `value` as unsigned decimal (scores/counters) |
+| `gen2_wait_vbl()`            | coarse spin until vertical blank |
+| `gen2_text()` … `gen2_hires()` | the eight `$C25x` soft-switch macros |
+
+## Minimal program
+
+```c
+#include "gen2.h"
+#include "apple1io.h"          /* optional: terminal I/O on GEN2 too */
+
+void main(void) {
+    gen2_hgr_init();
+    gen2_hgr_clear(0);                       /* black */
+    gen2_hgr_puts(42, 80, "HELLO WORLD");
+    gen2_hgr_putu(42, 100, 12345u);          /* a number */
+    woz_puts((const unsigned char *)"drawn on GEN2\r");
+    for (;;) { }
+}
+```
+
+Build (run `6000R`):
+
+```bash
+cl65 -t none -Oirs -C ../../cc65/apple1_gen2_c.cfg -I . -I ../apple1c \
+     hello.c gen2.c ../apple1c/apple1io.c ../apple1c/apple1io_asm.s -o hello.bin
+```
+
+Or just pick **GEN2 HGR (C)** in the *POM1 Bench* — it wires all of this for you.
+
+## Two gotchas (read these)
+
+1. **Never write the soft switches** (`STA $C25x`). A *read* toggles them and
+   returns the H/V-blank flag (HST0) in bit 7; the low 7 bits are an unreliable
+   floating bus. The `gen2_*()` macros read, never write.
+2. **Don't clear the framebuffer with a naïve 16-bit pointer loop.**
+   `for (i = 0; i < 8192; i++) p[i] = 0;` is ~20× slower (it drags in cc65's
+   16-bit pointer-increment helper) and blanks the screen for seconds. Use
+   `gen2_hgr_clear()`, which fills a page at a time with an 8-bit index (see the
+   comment in `gen2.c`).
+
+Full card reference (soft switches, HST0, beam timing): [`doc/GEN2_RELEASE.md`](../../../doc/GEN2_RELEASE.md).
+Full C guide: [`dev/Programming_Apple1_C.md`](../../Programming_Apple1_C.md).
+
+## Credit
+
+Beautiful Boot 8×8 font extracted from `dev/lib/hgr/bbfont_cp437.inc`. GEN2 card
+by Uncle Bernie. HIRES interleave modelled on cc65's apple2 target.

--- a/dev/lib/gen2c/gen2.c
+++ b/dev/lib/gen2c/gen2.c
@@ -202,3 +202,17 @@ void gen2_hgr_puts(unsigned x, unsigned char y, const char *s)
         cx += 18u;   /* 16px glyph + 2px gap */
     }
 }
+
+/* Unsigned decimal at (x, y) via gen2_hgr_puts. Builds the digits right-to-left
+ * into a 6-byte buffer (max 65535 = 5 digits + NUL), no leading zeros. */
+void gen2_hgr_putu(unsigned x, unsigned char y, unsigned value)
+{
+    char buf[6];
+    unsigned char i = 6;
+    buf[--i] = 0;                    /* buf[5] = NUL terminator */
+    do {
+        buf[--i] = (char)('0' + value % 10u);
+        value /= 10u;
+    } while (value != 0u);
+    gen2_hgr_puts(x, y, buf + i);
+}

--- a/dev/lib/gen2c/gen2.h
+++ b/dev/lib/gen2c/gen2.h
@@ -51,6 +51,10 @@ void gen2_hgr_plot(unsigned x, unsigned char y);
  * + gen2_hgr_clear first. Non-printable chars render as a space. */
 void gen2_hgr_puts(unsigned x, unsigned char y, const char *s);
 
+/* Draw `value` as unsigned decimal at (x, y), same 16x16 white cells / font as
+ * gen2_hgr_puts (1-5 digits, no leading zeros). Handy for scores and counters. */
+void gen2_hgr_putu(unsigned x, unsigned char y, unsigned value);
+
 /* Coarse spin until vertical blank (NOT cycle-exact — for tight beam-racing use
  * the ASM dev/lib/gen2 gen2_beam_lock). Double-samples HST0 to skip the colour-
  * burst notch and tells V-blank from H-blank by how long the blank lasts. */

--- a/dev/projects/_template/Hello.asm
+++ b/dev/projects/_template/Hello.asm
@@ -1,0 +1,28 @@
+; Hello.asm — the smallest useful Apple-1 program. Prints a string through the
+; WOZ Monitor ECHO routine, then returns to the Monitor.
+;
+; COPY THIS FOLDER to start your own asm project. Build: `make` (or by hand,
+; see README.md). Load the .bin/.txt in POM1 and run with 280R.
+;
+; Two rules you must know (see dev/Programming_Apple1_ASM.md §2):
+;   - bit 7 = data-valid: ORA #$80 before printing a char; CR is $0D here and
+;     ECHO adds the high bit. The keyboard is UPPERCASE only.
+;   - return to the Monitor with JMP WOZMON, never RTS (R doesn't push a return).
+
+.include "apple1.inc"          ; ECHO, WOZMON, KBD, DSP… (needs -I ../../lib/apple1)
+
+.segment "CODE"
+start:
+        ldx #0
+loop:
+        lda msg,x
+        beq done
+        ora #$80               ; set bit 7, then print A
+        jsr ECHO
+        inx
+        bne loop
+done:
+        jmp WOZMON             ; back to the '\' prompt
+
+msg:
+        .byte $0D, "HELLO WORLD", $0D, $00

--- a/dev/projects/_template/Makefile
+++ b/dev/projects/_template/Makefile
@@ -1,0 +1,9 @@
+# _template — minimal Apple-1 text program (copy this folder to start a project).
+# `make` assembles Hello.asm -> software/Apple-1 demos/Hello.bin (+ .txt with
+# EMIT_TXT). For the C variant (hello.c) see the cl65 line in README.md.
+PROJECT  := Hello
+LOAD_CFG := ../../cc65/apple1_4k.cfg
+OUT_DIR  := ../../../software/Apple-1 demos
+LIB      := -I ../../lib/apple1
+
+include ../../cc65/Makefile.common

--- a/dev/projects/_template/README.md
+++ b/dev/projects/_template/README.md
@@ -1,0 +1,54 @@
+# _template — minimal Apple-1 "hello world" (copy me)
+
+The smallest useful Apple-1 program, in both **assembly** and **C**. Copy this
+whole folder, rename, and start editing. Sorts to the top of `dev/projects/`
+thanks to the leading `_`.
+
+## Assembly (`Hello.asm`)
+
+```bash
+make                    # -> ../../../software/Apple-1 demos/Hello.bin
+```
+
+By hand:
+
+```bash
+ca65 -I ../../lib/apple1 Hello.asm -o Hello.o
+ld65 -C ../../cc65/apple1_4k.cfg Hello.o -o Hello.bin
+```
+
+Run in POM1: **File > Load Memory > Hello.bin**, then `280R`.
+
+## C (`hello.c`)
+
+```bash
+cl65 -t none -Oirs -C ../../cc65/apple1_c.cfg -I ../../lib/apple1c \
+     hello.c ../../lib/apple1c/apple1io.c ../../lib/apple1c/apple1io_asm.s \
+     -o hello.bin
+```
+
+Run in POM1: **File > Load Memory > hello.bin**, then `0300R`.
+
+## Even easier — the POM1 Bench
+
+Skip the command line: *DevBench → POM1 Bench*, **New → Apple-1 dual 4K/8K (text)
+— start here**, then **Upload**. The Bench drops in the same starter and runs it
+in one click (it needs `cc65` installed — it'll tell you how if it's missing).
+
+## Next steps
+
+- Assembly → [`dev/Programming_Apple1_ASM.md`](../../Programming_Apple1_ASM.md),
+  playbook [`dev/APPLE1DEV.md`](../../APPLE1DEV.md).
+- C → [`dev/Programming_Apple1_C.md`](../../Programming_Apple1_C.md).
+- Add graphics: HGR (`dev/lib/gen2c/`), TMS9918 (`dev/apple1-videocard-lib/`),
+  or GT-6144 (`dev/projects/gt6144_hello/`).
+
+## Hardware
+
+- Machine: Apple 1 (stock 4 KB is enough)
+- Cards: none
+- Recommended POM1 preset: **1** (Apple-1 with ACI & BASIC) — any text preset works.
+
+## License
+
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository [LICENSE](../../../LICENSE)).

--- a/dev/projects/_template/hello.c
+++ b/dev/projects/_template/hello.c
@@ -1,0 +1,19 @@
+/* hello.c — the smallest useful Apple-1 program in C. Prints a string through
+ * the WOZ Monitor, then returns to it.
+ *
+ * COPY THIS FOLDER to start your own C project. Build by hand (the Makefile
+ * builds the asm Hello.asm; for C use the command in README.md), then load the
+ * .bin in POM1 and run with 0300R.
+ *
+ * Notes (see dev/Programming_Apple1_C.md):
+ *   - void main(void), not int main() — there's no OS to return to.
+ *   - No <stdio.h>/printf — print with woz_puts / woz_putc.
+ *   - apple1io.h is the shared, card-neutral text/keyboard base; the same header
+ *     works on the GEN2 HGR card too.
+ */
+#include "apple1io.h"          /* needs -I ../../lib/apple1c */
+
+void main(void) {
+    woz_puts((const unsigned char *)"\rHELLO WORLD (C)\r");
+    woz_mon();                 /* back to the '\' prompt */
+}

--- a/dev/projects/a1io_rtc_clock/README.md
+++ b/dev/projects/a1io_rtc_clock/README.md
@@ -9,8 +9,7 @@ refresh. Reads broadcast registers from the emulated ATMEGA32 over the
 
 - Machine: Apple 1 (4 KB DRAM is enough)
 - Cards: P-LAB A1-IO & RTC
-- Recommended POM1 preset: TODO — pick the A1-IO & RTC preset from the
-  Presets menu.
+- Recommended POM1 preset: 8 (P-LAB I/O Board & RTC).
 
 ## Sources
 
@@ -28,10 +27,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → A1-IO & RTC preset (TODO).
+1. POM1 → Presets → preset 8 (P-LAB I/O Board & RTC).
 2. File → Load → `software/a1io_rtc/RtcClock.bin` (or the matching `.txt`).
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-TODO — fill in author + license for the source.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/demo_maze/README.md
+++ b/dev/projects/demo_maze/README.md
@@ -11,7 +11,7 @@ Apple 1 terminal. Each shows a title screen and marks `S` (start) and
 
 - Machine: Apple 1 (stock 4 KB DRAM)
 - Cards: none
-- Recommended POM1 preset: TODO — any text-only Apple 1 preset.
+- Recommended POM1 preset: 1 (Apple-1 with ACI & BASIC; any text preset works).
 
 ## Sources
 
@@ -30,10 +30,10 @@ By hand (one program at a time):
 
 ## Run in POM1
 
-1. POM1 → Presets → any text-mode Apple 1 preset (TODO).
+1. POM1 → Presets → preset 1 (Apple-1 with ACI & BASIC).
 2. File → Load → `software/games/Maze_Sidewinder.bin` (or `Maze2_Backtracker.bin`).
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/games_connect4/README.md
+++ b/dev/projects/games_connect4/README.md
@@ -8,7 +8,7 @@ first to align four wins.
 
 - Machine: Apple 1 (stock 4 KB DRAM)
 - Cards: none
-- Recommended POM1 preset: TODO — any text-only Apple 1 preset works.
+- Recommended POM1 preset: 1 (Apple-1 with ACI & BASIC; any text preset works).
 
 ## Sources
 
@@ -26,10 +26,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → any text-mode Apple 1 preset (TODO).
+1. POM1 → Presets → preset 1 (Apple-1 with ACI & BASIC).
 2. File → Load → `software/games/Connect4.bin`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/games_little_tower/README.md
+++ b/dev/projects/games_little_tower/README.md
@@ -10,7 +10,7 @@ in stock 8 KB DRAM (~6 KB binary, no expansion cards required).
 
 - Machine: Apple 1 (stock 4 KB DRAM is enough)
 - Cards: none
-- Recommended POM1 preset: TODO — any text-only Apple 1 preset.
+- Recommended POM1 preset: 1 (Apple-1 with ACI & BASIC; any text preset works).
 
 ## Sources
 
@@ -28,10 +28,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → any text-mode Apple 1 preset (TODO).
+1. POM1 → Presets → preset 1 (Apple-1 with ACI & BASIC).
 2. File → Load → `software/games/LittleTower-1.0.bin`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-VERHILLE Arnaud, September 2000 (refreshed April 2026). License: TODO.
+VERHILLE Arnaud, September 2000 (refreshed April 2026). License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/games_sokoban/README.md
+++ b/dev/projects/games_sokoban/README.md
@@ -12,7 +12,7 @@ with no expansion RAM.
   Larger budgets (`apple1_sok_8k.cfg`, `apple1_sok_hgr.cfg`) ship for
   variants that target 8 KB / GEN2 HGR setups respectively.
 - Cards: none (the HGR variant is consumed by `dev/projects/hgr_sokoban/`)
-- Recommended POM1 preset: TODO — any text-mode Apple 1 preset.
+- Recommended POM1 preset: 1 (Apple-1 with ACI & BASIC; any text preset works).
 
 ## Sources
 
@@ -33,11 +33,11 @@ By hand (any of the three variants):
 
 ## Run in POM1
 
-1. POM1 → Presets → any text-mode Apple 1 preset (TODO).
+1. POM1 → Presets → preset 1 (Apple-1 with ACI & BASIC).
 2. File → Load → `software/games/Sokoban.bin`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
 VERHILLE Arnaud, 2026. Microban I levels by David W. Skinner (2000).
-License: TODO.
+License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/gt6144_hello/README.md
+++ b/dev/projects/gt6144_hello/README.md
@@ -12,7 +12,7 @@ rectangles") and draws two centred lines with a 3×5-pixel font:
 
 - Machine: Apple 1 (stock 4 KB)
 - Cards: SWTPC GT-6144 (write-only port at `$D00A`)
-- Recommended POM1 preset: TODO — pick the GT-6144 preset.
+- Recommended POM1 preset: 2 (Apple-1 + SWTPC GT-6144).
 
 ## Sources
 
@@ -31,10 +31,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GT-6144 preset (TODO).
+1. POM1 → Presets → preset 2 (Apple-1 + SWTPC GT-6144).
 2. File → Load → `software/gt-6144/GT1_Hello.bin`.
 3. Wozmon `\` prompt: type `300R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/gt6144_life/README.md
+++ b/dev/projects/gt6144_life/README.md
@@ -11,7 +11,7 @@ animate a Life grid in real time.
 
 - Machine: Apple 1 (stock 4 KB)
 - Cards: SWTPC GT-6144
-- Recommended POM1 preset: TODO — pick the GT-6144 preset.
+- Recommended POM1 preset: 2 (Apple-1 + SWTPC GT-6144).
 
 ## Sources
 
@@ -30,10 +30,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GT-6144 preset (TODO).
+1. POM1 → Presets → preset 2 (Apple-1 + SWTPC GT-6144).
 2. File → Load → `software/gt-6144/GT1_Life.bin`.
 3. Wozmon `\` prompt: type `300R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_bbfont_show/README.md
+++ b/dev/projects/hgr_bbfont_show/README.md
@@ -9,7 +9,7 @@ non-Wozmon characters.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -29,10 +29,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_BBFontShow.bin`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_connect4/README.md
+++ b/dev/projects/hgr_connect4/README.md
@@ -7,7 +7,7 @@ Card.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -26,10 +26,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_Connect4.bin`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_house/README.md
+++ b/dev/projects/hgr_house/README.md
@@ -7,7 +7,7 @@ Color Graphics Card, exercising the NTSC artifact-colour palette.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -26,10 +26,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_House.bin`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_life/README.md
+++ b/dev/projects/hgr_life/README.md
@@ -9,7 +9,7 @@ pattern, ESC to exit.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -30,10 +30,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_Life.txt`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_mandelbrot/README.md
+++ b/dev/projects/hgr_mandelbrot/README.md
@@ -8,7 +8,7 @@ Inspired by Fred Stark's text-mode `mandelbrot-65`.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -29,10 +29,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_Mandelbrot.txt`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_maze/README.md
+++ b/dev/projects/hgr_maze/README.md
@@ -9,7 +9,7 @@ fringing on cell borders).
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -28,10 +28,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_Maze.bin`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_orbital_pool/README.md
+++ b/dev/projects/hgr_orbital_pool/README.md
@@ -23,7 +23,7 @@ re-validate the other.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -44,10 +44,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_OrbitalPool.txt`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_sierpinski/README.md
+++ b/dev/projects/hgr_sierpinski/README.md
@@ -8,7 +8,7 @@ classic `(x AND y) == 0` rule.
 
 - Machine: Apple 1 (8 KB DRAM — GEN2 framebuffer at `$2000-$3FFF`)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -27,10 +27,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_Sierpinski.bin`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_sokoban/README.md
+++ b/dev/projects/hgr_sokoban/README.md
@@ -8,7 +8,7 @@ via `dev/lib/games/sokoban/`, swapping the text renderer for HGR sprites.
 
 - Machine: Apple 1 (8 KB DRAM, GEN2 framebuffer at `$2000-$3FFF`)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -29,11 +29,11 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_Sokoban.bin`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
 VERHILLE Arnaud, 2026. Microban I levels by David W. Skinner (2000).
-License: TODO.
+License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/hgr_testcard/README.md
+++ b/dev/projects/hgr_testcard/README.md
@@ -8,7 +8,7 @@ reference image for tuning monitor / emulator colour.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: GEN2 HGR
-- Recommended POM1 preset: TODO — pick a GEN2 HGR preset.
+- Recommended POM1 preset: 12 (Uncle Bernie's GEN2 HGR Color).
 
 ## Sources
 
@@ -27,10 +27,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → GEN2 HGR preset (TODO).
+1. POM1 → Presets → preset 12 (Uncle Bernie's GEN2 HGR Color).
 2. File → Load → `software/hgr/HGR_TestCard.bin`.
 3. Wozmon `\` prompt: type `E000R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/sid_piano/README.md
+++ b/dev/projects/sid_piano/README.md
@@ -12,7 +12,7 @@ fixed-position screen buffer at `$0850`.
 
 - Machine: Apple 1 (4 KB DRAM is enough)
 - Cards: P-LAB A1-SID
-- Recommended POM1 preset: TODO — pick the SID preset.
+- Recommended POM1 preset: 6 (P-LAB A1-SID).
 
 ## Sources
 
@@ -32,11 +32,11 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → SID preset (TODO).
+1. POM1 → Presets → preset 6 (P-LAB A1-SID).
 2. File → Load → `software/sid/Claudio_PARMIGIANI_SID_PIANO_AZERTY.bin`.
 3. Wozmon `\` prompt: type `600R`.
 
 ## Author / License
 
 Claudio Parmigiani, 2019 (original). AZERTY port: VERHILLE Arnaud, 2026.
-License: TODO.
+License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_clone/README.md
+++ b/dev/projects/tms9918_clone/README.md
@@ -114,4 +114,4 @@ If POM1 renders clones IN LEGAL Mode I (where it shouldn't),
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_codetank_menu/README.md
+++ b/dev/projects/tms9918_codetank_menu/README.md
@@ -46,4 +46,4 @@ By hand:
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_codetank_menu_upper/README.md
+++ b/dev/projects/tms9918_codetank_menu_upper/README.md
@@ -61,4 +61,4 @@ The 128 B `.bin` then ships embedded inside `roms/codetank/Codetank_GAME1.rom`
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_connect4/README.md
+++ b/dev/projects/tms9918_connect4/README.md
@@ -8,7 +8,7 @@ Graphic Card. Companion of `games_connect4` (text mode) and
 
 - Machine: Apple 1 (4 KB DRAM is enough)
 - Cards: P-LAB TMS9918
-- Recommended POM1 preset: TODO — pick a TMS9918 preset.
+- Recommended POM1 preset: 7 (P-LAB TMS9918 + CodeTank).
 
 ## Sources
 
@@ -27,10 +27,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → TMS9918 preset (TODO).
+1. POM1 → Presets → preset 7 (P-LAB TMS9918 + CodeTank).
 2. File → Load → `software/tms9918/TMS_Connect4.bin`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_galaga/README.md
+++ b/dev/projects/tms9918_galaga/README.md
@@ -31,8 +31,7 @@ stitched from four quadrants (`P_SUPER_{TL,TR,BL,BR}`).
 
 - Machine: Apple 1 (4 KB DRAM for the cassette build)
 - Cards: P-LAB TMS9918 (CodeTank for the ROM variants)
-- Recommended POM1 preset: TODO — pick a TMS9918 preset; preset 7 for
-  the CodeTank variants.
+- Recommended POM1 preset: 7 (P-LAB TMS9918 + CodeTank).
 
 ## Sources
 
@@ -54,7 +53,7 @@ Override the linker config from the command line:
 
 ## Run in POM1
 
-1. POM1 → Presets → TMS9918 preset (preset 7 for CodeTank).
+1. POM1 → Presets → preset 7 (P-LAB TMS9918 + CodeTank).
 2. File → Load → `software/tms9918/TMS_Galaga.txt`.
 3. Wozmon `\` prompt: type `280R` (cassette), `4000R` (CodeTank lower —
    menu/split/dualslot8k all map Galaga at or near `$4000`).
@@ -86,4 +85,4 @@ Snake / Life entries are dropped from this ROM but can be revived via
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_life/README.md
+++ b/dev/projects/tms9918_life/README.md
@@ -16,8 +16,7 @@ Two linker-config variants:
 
 - Machine: Apple 1 (4 KB DRAM for cassette; 8 KB to play comfortably)
 - Cards: P-LAB TMS9918 (CodeTank for the bank variant)
-- Recommended POM1 preset: TODO — pick a TMS9918 preset; preset 7 for
-  the CodeTank variant.
+- Recommended POM1 preset: 7 (P-LAB TMS9918 + CodeTank).
 
 ## Sources
 
@@ -36,10 +35,10 @@ Override the linker config from the command line:
 
 ## Run in POM1
 
-1. POM1 → Presets → TMS9918 preset (TODO; preset 7 for CodeTank).
+1. POM1 → Presets → preset 7 (P-LAB TMS9918 + CodeTank).
 2. File → Load → `software/tms9918/TMS_Life.txt`.
 3. Wozmon `\` prompt: type `280R` (cassette) or `7A00R` (CodeTank).
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_logo/README.md
+++ b/dev/projects/tms9918_logo/README.md
@@ -243,4 +243,4 @@ was retired with option B; the lib stays pristine).
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_maze3d/README.md
+++ b/dev/projects/tms9918_maze3d/README.md
@@ -9,7 +9,7 @@ down map toggle, turn-based combat against three monster archetypes.
 
 - Machine: Apple 1 (8 KB DRAM)
 - Cards: P-LAB TMS9918
-- Recommended POM1 preset: TODO — pick a TMS9918 preset.
+- Recommended POM1 preset: 7 (P-LAB TMS9918 + CodeTank).
 
 ## Sources
 
@@ -32,10 +32,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → TMS9918 preset (TODO).
+1. POM1 → Presets → preset 7 (P-LAB TMS9918 + CodeTank).
 2. File → Load → `software/tms9918/TMS_Maze3D.txt`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_orbital_pool/README.md
+++ b/dev/projects/tms9918_orbital_pool/README.md
@@ -22,7 +22,7 @@ gameplay, distinct code. If you re-tune one, re-validate the other.
 
 - Machine: Apple 1 (4 KB DRAM)
 - Cards: P-LAB TMS9918
-- Recommended POM1 preset: TODO — pick a TMS9918 preset.
+- Recommended POM1 preset: 7 (P-LAB TMS9918 + CodeTank).
 
 ## Sources
 
@@ -43,10 +43,10 @@ By hand:
 
 ## Run in POM1
 
-1. POM1 → Presets → TMS9918 preset (TODO).
+1. POM1 → Presets → preset 7 (P-LAB TMS9918 + CodeTank).
 2. File → Load → `software/tms9918/TMS_OrbitalPool.txt`.
 3. Wozmon `\` prompt: type `280R`.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_silbench/README.md
+++ b/dev/projects/tms9918_silbench/README.md
@@ -135,4 +135,4 @@ silicon-strict log — any mismatch flags either:
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_snake/README.md
+++ b/dev/projects/tms9918_snake/README.md
@@ -16,8 +16,7 @@ Two linker-config variants:
 
 - Machine: Apple 1 (4 KB DRAM is enough)
 - Cards: P-LAB TMS9918 (CodeTank for the bank variant)
-- Recommended POM1 preset: TODO — pick a TMS9918 preset; preset 7 for
-  the CodeTank variant.
+- Recommended POM1 preset: 7 (P-LAB TMS9918 + CodeTank).
 
 ## Sources
 
@@ -38,10 +37,10 @@ Override the linker config from the command line:
 
 ## Run in POM1
 
-1. POM1 → Presets → TMS9918 preset (TODO; preset 7 for CodeTank).
+1. POM1 → Presets → preset 7 (P-LAB TMS9918 + CodeTank).
 2. File → Load → `software/tms9918/TMS_Snake.txt`.
 3. Wozmon `\` prompt: type `280R` (cassette) or `7100R` (CodeTank).
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_sokoban/README.md
+++ b/dev/projects/tms9918_sokoban/README.md
@@ -44,4 +44,4 @@ Override the linker config from the command line:
 ## Author / License
 
 VERHILLE Arnaud, 2026. Microban I levels by David W. Skinner (2000).
-License: TODO.
+License: GPL-3.0 (see repository LICENSE).

--- a/dev/projects/tms9918_split/README.md
+++ b/dev/projects/tms9918_split/README.md
@@ -53,4 +53,4 @@ upload to fit one scan line.
 
 ## Author / License
 
-VERHILLE Arnaud, 2026. License: TODO.
+VERHILLE Arnaud, 2026. License: GPL-3.0 (see repository LICENSE).

--- a/doc/GEN2_RELEASE.md
+++ b/doc/GEN2_RELEASE.md
@@ -135,6 +135,13 @@ plot), `dev/lib/apple1/` (Wozmon/PIA equates, print). Multi-zone loading:
 `emit_woz.py` bundles raw blobs (e.g. an 8 KB HGR image at `$2000`) into the
 program's `.txt` via `extra_zones` — one Wozmon load installs everything.
 
+**Writing in C instead of asm?** Use the gen2c runtime —
+`dev/lib/gen2c/gen2.h` (`gen2_hgr_init` / `gen2_hgr_clear` / `gen2_hgr_plot` /
+`gen2_hgr_puts` / `gen2_hgr_putu`) linked with `dev/cc65/apple1_gen2_c.cfg`
+(CODE at `$6000`, both HGR pages reserved), plus the shared Apple-1 text/keyboard
+base `dev/lib/apple1c/` (`woz_puts`, `woz_getkey`). Full C guide:
+[`Programming_Apple1_C.md`](../dev/Programming_Apple1_C.md).
+
 ## 5. Sound: the ACI is the speaker (Q7)
 
 The release card moved its switches out of `$C0xx` precisely so the ACI

--- a/src/Pom1BenchHost.cpp
+++ b/src/Pom1BenchHost.cpp
@@ -290,8 +290,9 @@ static const char* kSketchTxtGen2C =     // C x GEN2 native TEXT mode ($0400)
     "    for (;;) { /* idle */ }\n"
     "}\n";
 static const char* kSketchCText =        // C x Apple dual-4k/8k (WozMon I/O)
-    "/* HELLO WORLD in C on a plain text Apple-1 (apple1.c woz_puts, cc65). */\n"
-    "#include \"apple1.h\"\n"
+    "/* HELLO WORLD in C on a plain text Apple-1, using the shared apple1c text\n"
+    "   base (woz_puts/woz_getkey). The same apple1io.h works on the GEN2 card. */\n"
+    "#include \"apple1io.h\"\n"
     "\n"
     "void main(void) {\n"
     "    woz_puts((const unsigned char *)\"\\rHELLO WORLD (C / Apple-1)\\r\");\n"
@@ -392,14 +393,14 @@ const char* const kP1LanguageHints[] = {
     "apple1-videocard-lib (TMS9918) / gen2 C runtime depending on the target.",
 };
 const char* const kP1Machines[]  = {
-    "Apple-1 dual 4K/8K  (text)",
+    "Apple-1 dual 4K/8K  (text) - start here",
     "P-LAB Graphic Card  (TMS9918)",
     "Uncle Bernie GEN2 HGR  (colour)",
     "Bernie GEN2 TXT  (40x24 text)",
 };
 const char* const kP1MachineHints[] = {
     "Stock Apple-1: 40x24 text printed through the WozMon ECHO routine ($FFEF).\n"
-    "Preset 1 (dual 4K/8K RAM).",
+    "Easiest place to start - no graphics card needed. Preset 1 (dual 4K/8K RAM).",
     "P-LAB Graphic Card by Claudio Parmigiani — TMS9918 VDP, Graphics I mode,\n"
     "256x192, data port $CC00 / control $CC01. Preset 7.",
     "Uncle Bernie's GEN2 colour card — Apple II-style HIRES (280x192) driven by\n"
@@ -475,6 +476,33 @@ void parseErrorMarkers(const std::string& out, std::vector<std::pair<int, std::s
     }
 }
 
+// Cross-platform install nudge appended whenever the cc65 toolchain (or the dev/
+// source tree it needs) is missing — turns a dead-end "not found" into a fix.
+const char* const kCc65InstallHint =
+    "\nInstall the cc65 toolchain, then reopen the Bench:\n"
+    "  Debian/Ubuntu : sudo apt install cc65\n"
+    "  Fedora        : sudo dnf install cc65\n"
+    "  Arch          : sudo pacman -S cc65\n"
+    "  macOS         : brew install cc65\n"
+    "  Windows/other : https://cc65.github.io/  (add its bin/ to PATH)\n";
+
+// Plain-language one-liner for the most common ca65/ld65/cl65 diagnostics, so a
+// newcomer gets a nudge above the raw toolchain spew. Empty if nothing matches.
+std::string humanizeCc65(const std::string& out)
+{
+    auto has = [&](const char* s) { return out.find(s) != std::string::npos; };
+    std::string tip;
+    if (has("ndefined"))            // "Symbol ... undefined" / "Undefined external"
+        tip = "an undefined label/symbol - check spelling, or add its definition / .include.";
+    else if (has("Range error"))
+        tip = "a value is out of range - over 255 for an 8-bit operand, or a branch over 127 bytes away.";
+    else if (has("verflow") || has("emory configuration"))
+        tip = "the program is too big for the linker config - shrink it or pick a roomier target.";
+    else if (has("Unknown identifier") || has("nknown opcode") || has("yntax error"))
+        tip = "a typo or unknown name on the flagged line - check the mnemonic / identifier.";
+    return tip.empty() ? std::string() : "[bench] Hint: " + tip + "\n";
+}
+
 } // namespace
 
 // ─────────────────────────────────────────────────────────────
@@ -530,12 +558,17 @@ void Pom1BenchHost::probe() const
         const fs::path gcfg = fs::path(devRoot) / "cc65" / "apple1_gen2_c.cfg";
         if (fs::exists(glib, ec)) gen2cLib_ = fs::absolute(glib, ec).string();
         if (fs::exists(gcfg, ec)) gen2Cfg_  = fs::absolute(gcfg, ec).string();
-        // Plain text C (apple1.c woz_puts) uses dev/cc65/apple1_c.cfg.
+        // Plain text C uses dev/cc65/apple1_c.cfg + the shared apple1c text base.
         const fs::path pcfg = fs::path(devRoot) / "cc65" / "apple1_c.cfg";
         if (fs::exists(pcfg, ec)) plainCfg_ = fs::absolute(pcfg, ec).string();
+        // Shared Apple-1 text/keyboard C base (woz_puts/woz_getkey) — card-neutral,
+        // linked by both the plain-text and GEN2 HGR C targets so either can do
+        // terminal I/O. The graphics runtimes (gen2c / videocard-lib) sit on top.
+        const fs::path a1c = fs::path(devRoot) / "lib" / "apple1c";
+        if (fs::exists(a1c, ec)) apple1cLib_ = fs::absolute(a1c, ec).string();
     }
     gen2COk_  = !cl65_.empty() && !gen2cLib_.empty() && !gen2Cfg_.empty();
-    plainCOk_ = !cl65_.empty() && !videocardLib_.empty() && !plainCfg_.empty();
+    plainCOk_ = !cl65_.empty() && !apple1cLib_.empty() && !plainCfg_.empty();
 #endif
 }
 
@@ -657,6 +690,8 @@ bench::BuildResult Pom1BenchHost::build(int target, const std::string& src, cons
     }
 
 #if POM1_IS_WASM
+    r.console = "cc65 build is desktop-only - the in-browser POM1 has no ca65/ld65/cl65.\n"
+                "Compile in the desktop build, or paste a Wozmon hex dump (hex/raw target) instead.\n";
     r.status = "cc65 build is desktop-only"; return r;
 #else
     probe();
@@ -681,8 +716,10 @@ bench::BuildResult Pom1BenchHost::build(int target, const std::string& src, cons
         const bool ready = gen2c ? gen2COk_ : plainc ? plainCOk_ : cl65Ok_;
         if (!ready) {
             r.console = gen2c ? "cl65 / gen2c lib not found (needs dev/)\n"
-                      : plainc ? "cl65 / apple1.c lib not found (needs dev/)\n"
+                      : plainc ? "cl65 / apple1c lib not found (needs dev/)\n"
                                : "cl65 / videocard-lib not found (needs dev/)\n";
+            r.console += "The dev/ source tree must be present (clone the repo; release bundles omit dev/).\n";
+            r.console += kCc65InstallHint;
             r.status = "cc65 cl65 missing"; return r;
         }
         const fs::path srcC = dir / "pom1_bench.c";
@@ -691,16 +728,23 @@ bench::BuildResult Pom1BenchHost::build(int target, const std::string& src, cons
         std::string cmd; const char* tag;
         if (gen2c) {
             tag = "GEN2 HGR";
+            // Optionally fold in the shared apple1c text base so GEN2 C programs
+            // can also print to the WOZ terminal / read the keyboard.
+            std::string a1c;
+            if (!apple1cLib_.empty())
+                a1c = " -I " + bench::shellQuote(apple1cLib_) +
+                      " " + bench::shellQuote(apple1cLib_ + "/apple1io.c") +
+                      " " + bench::shellQuote(apple1cLib_ + "/apple1io_asm.s");
             cmd = bench::shellQuote(cl65_) + " -t none -Oirs -C " + bench::shellQuote(gen2Cfg_) +
-                " -I " + bench::shellQuote(gen2cLib_) + " " + bench::shellQuote(srcC.string()) +
+                " -I " + bench::shellQuote(gen2cLib_) + a1c + " " + bench::shellQuote(srcC.string()) +
                 " " + bench::shellQuote(gen2cLib_ + "/gen2.c") +
                 " -o " + bench::shellQuote(binB.string());
         } else if (plainc) {
             tag = "Apple-1 text";
-            const std::string& lib = videocardLib_;
+            const std::string& lib = apple1cLib_;   // shared, card-neutral text base
             cmd = bench::shellQuote(cl65_) + " -t none -Oirs -C " + bench::shellQuote(plainCfg_) +
                 " -I " + bench::shellQuote(lib) + " " + bench::shellQuote(srcC.string()) +
-                " " + bench::shellQuote(lib + "/apple1.c") + " " + bench::shellQuote(lib + "/apple1_asm.s") +
+                " " + bench::shellQuote(lib + "/apple1io.c") + " " + bench::shellQuote(lib + "/apple1io_asm.s") +
                 " -o " + bench::shellQuote(binB.string());
         } else {
             tag = "CodeTank ROM";
@@ -714,12 +758,12 @@ bench::BuildResult Pom1BenchHost::build(int target, const std::string& src, cons
         std::string out;
         const int rc = bench::runCapture(cmd, out);
         r.console = std::string("$ cl65 -t none [") + tag + "]\n" + out;
-        if (rc != 0) { parseErrorMarkers(out, r.errors); r.status = "cl65 failed (see Build output)"; return r; }
+        if (rc != 0) { parseErrorMarkers(out, r.errors); r.console += humanizeCc65(out); r.status = "cl65 failed (see Build output)"; return r; }
         r.console += std::string("[ok] compiled + linked (") + tag + ")\n";
         entry = gen2c ? parseCfgLoadAddr(gen2Cfg_) : plainc ? parseCfgLoadAddr(plainCfg_) : 0x4000;
         if (entry == 0) entry = plainc ? 0x0300 : 0x6000;
     } else {
-        if (!toolchainOk_) { r.console = "cc65 (ca65/ld65) not found\n"; r.status = "cc65 missing"; return r; }
+        if (!toolchainOk_) { r.console = std::string("cc65 (ca65/ld65) not found.\n") + kCc65InstallHint; r.status = "cc65 missing"; return r; }
         const fs::path srcS = dir / "pom1_bench.s";
         const fs::path objO = dir / "pom1_bench.o";
         sweep.add(srcS); sweep.add(objO);
@@ -742,12 +786,12 @@ bench::BuildResult Pom1BenchHost::build(int target, const std::string& src, cons
             bench::shellQuote(srcS.string()) + " -o " + bench::shellQuote(objO.string());
         int rc = bench::runCapture(ca, out);
         r.console = "$ ca65 [" + std::string(t.label) + "]\n" + out;
-        if (rc != 0) { parseErrorMarkers(out, r.errors); r.status = "ca65 failed (see Build output)"; return r; }
+        if (rc != 0) { parseErrorMarkers(out, r.errors); r.console += humanizeCc65(out); r.status = "ca65 failed (see Build output)"; return r; }
         const std::string ld = bench::shellQuote(ld65_) + " -C " + bench::shellQuote(cfgPath) + " " +
             bench::shellQuote(objO.string()) + " -o " + bench::shellQuote(binB.string());
         rc = bench::runCapture(ld, out);
         r.console += "$ ld65 -C " + cfgPath + "\n" + out;
-        if (rc != 0) { r.status = "ld65 failed (see Build output)"; return r; }
+        if (rc != 0) { r.console += humanizeCc65(out); r.status = "ld65 failed (see Build output)"; return r; }
         r.console += "[ok] assembled + linked\n";
         entry = parseCfgLoadAddr(cfgPath);
         if (entry == 0) { try { entry = static_cast<uint16_t>(std::stoul(addrHex, nullptr, 16)); } catch (...) { entry = 0x0300; } }

--- a/src/Pom1BenchHost.h
+++ b/src/Pom1BenchHost.h
@@ -66,9 +66,9 @@ private:
     mutable bool        toolchainOk_ = false;
     mutable bool        cl65Ok_      = false;   // TMS9918 CodeTank C (videocard lib)
     mutable bool        gen2COk_     = false;   // GEN2 HGR C (gen2c lib)
-    mutable bool        plainCOk_    = false;   // plain text C (apple1.c lib)
+    mutable bool        plainCOk_    = false;   // plain text C (shared apple1c lib)
     mutable std::string ca65_, ld65_, cl65_, libFlags_, videocardLib_, codetankCfg_;
-    mutable std::string gen2cLib_, gen2Cfg_, plainCfg_;
+    mutable std::string gen2cLib_, gen2Cfg_, plainCfg_, apple1cLib_;
 };
 
 #endif // POM1_BENCH_HOST_H


### PR DESCRIPTION
## Summary

This PR adds comprehensive C programming support to POM1, including a new shared Apple-1 text/keyboard library (`apple1c`), a GEN2 HGR C runtime (`gen2c`), full documentation, and integration into the POM1 Bench IDE. Users can now write Apple-1 programs in C using cc65, with a unified API across text, GEN2, and TMS9918 targets.

## Key Changes

### Documentation & Guides
- **`QUICKSTART.md`** — New 5-minute getting-started guide for first-time users (BASIC, WOZ Monitor, Bench intro)
- **`dev/Programming_Apple1_C.md`** — Complete C programming guide covering installation, architecture, all three targets (text/GEN2/TMS9918), memory budgets, and common gotchas
- **`dev/lib/apple1c/README.md`** — API reference for the shared text/keyboard base
- **`dev/lib/gen2c/README.md`** — GEN2 HGR C runtime guide with soft-switch gotchas
- **`dev/projects/_template/README.md`** — Template project documentation (copy-to-start pattern)

### Core Libraries
- **`dev/lib/apple1c/`** — New card-neutral text/keyboard library (shared by all C targets)
  - `apple1io.h` — Public API (`woz_puts`, `woz_getkey`, `woz_mon`, etc.)
  - `apple1io.c` — C layer (string helpers, keyboard polling)
  - `apple1io_asm.s` — Assembly shim calling WOZ Monitor ROM directly
- **`dev/lib/gen2c/gen2.c`** — Added `gen2_hgr_putu()` for unsigned decimal rendering

### Template Project
- **`dev/projects/_template/`** — Minimal "hello world" in both assembly and C
  - `Hello.asm` / `hello.c` — Starter programs
  - `Makefile` — Build automation
  - `README.md` — Instructions for copying and extending

### POM1 Bench Integration
- **`src/Pom1BenchHost.cpp`** — Enhanced C sketch support
  - Updated `kSketchCText` template to use `apple1io.h` (was `apple1.h`)
  - Added `humanizeCc65()` function to translate cc65 diagnostics into plain-language hints
  - Added `kCc65InstallHint` cross-platform installation nudge
  - Improved machine/language hints ("start here" callout on text target)
  - Probes for cc65 toolchain and gen2c library availability
- **`bench/CodeBench.cpp`** — Added load-address field UI for raw-bytes target

### Documentation Updates
- **`README.md`** — Updated 60-second tour with BASIC/SID examples and QUICKSTART link
- **`dev/APPLE1DEV.md`** — Added C rows to decision table; linked to `Programming_Apple1_C.md`
- **`doc/GEN2_RELEASE.md`** — Added C runtime reference
- **Multiple project READMEs** — Filled in "Recommended POM1 preset" fields (were "TODO")

## Implementation Details

- **Card-neutral design**: `apple1c` has zero dependency on graphics cards; GEN2 and TMS9918 runtimes layer on top, allowing the same text API everywhere
- **Toolchain hints**: When cc65 is missing or a build fails, the Bench now shows actionable installation/fix guidance instead of raw compiler errors
- **Memory budgets**: Three linker configs documented (`apple1_c.cfg` ~2.75 KB, `apple1_gen2_c.cfg` ~24 KB, `codetank_c.cfg` 16 KB ROM)
- **Asm shim naming**: `apple1io_asm.s` (not `apple1io.s`) to avoid clobbering cc65's intermediate file
-

https://claude.ai/code/session_01JYPnWj3HBWcJ3MGJ4RHrAG