### PR TITLE
ci: minimal GitHub Actions workflow (build + ctest + dev build-all)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+# Minimal CI: build POM1 on Linux, run the ctest suite (Klaus functional test +
+# every smoke test + the GEN2 graphics-regression golden), and assemble all the
+# dev/ 6502 projects. Single Linux job by design — see CLAUDE.md / TODO.md.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libglfw3-dev libgl1-mesa-dev cc65
+
+      - name: Fetch Dear ImGui (pinned to the tested release)
+        run: git clone --depth 1 --branch v1.92.7 https://github.com/ocornut/imgui.git
+
+      - name: Build POM1
+        run: |
+          cmake -S . -B build
+          cmake --build build -j"$(nproc)"
+
+      - name: Run ctest (Klaus, smoke tests, graphics regression)
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Assemble all dev/ 6502 projects
+        run: make -C dev/projects


### PR DESCRIPTION
## Summary

The repo's first **CI** — deliberately **minimal**: a single Linux job, no OS matrix, no WASM build, no caching. It's the automated regression gate that ties together the work from this session.

## What it does (on push to `main` / any PR)

1. Install deps: `cmake g++ libglfw3-dev libgl1-mesa-dev cc65`.
2. Fetch Dear ImGui pinned to the tested **v1.92.7** (unpinned `master` risks API drift).
3. Build POM1.
4. `ctest --output-on-failure` — Klaus 6502 functional test + every smoke test + the new GEN2 **graphics-regression** golden (`gfx_regress_gen2_testcard`).
5. `make -C dev/projects` — assemble all 52 dev/ 6502 projects.

## Verification (local, this environment)

- Full `ctest`: **100% passed, 0 failed out of 30** (6 s).
- `make -C dev/projects`: **52/52** projects assemble.
- The deps + imgui-pin + cmake build steps are exactly the commands used to build POM1 here.

So every workflow step is locally confirmed green before merge; opening this PR also runs the workflow live as a second confirmation.

https://claude.ai/code/session_01WE1NNLXnprBryHeHTVm428

---
_Generated by [Claude Code](https://claude.ai/code/session_01WE1NNLXnprBryHeHTVm428)_