### PR TITLE
6502: selectable NMOS decimal ADC/SBC bug vs 65C02-corrected (Silicon window)

### DIFF
--- a/src/EmulationController.cpp
+++ b/src/EmulationController.cpp
@@ -514,6 +514,19 @@ bool EmulationController::isSiliconStrictMode() const
     return memory->isSiliconStrictMode();
 }
 
+void EmulationController::setCpuDecimalBugNMOS(bool enabled)
+{
+    std::lock_guard<PriorityMutex> lock(stateMutex);
+    cpu->setDecimalBugNMOS(enabled);
+    publisher.publish(*memory, *cpu, runRequested.load());
+}
+
+bool EmulationController::isCpuDecimalBugNMOS() const
+{
+    std::lock_guard<PriorityMutex> lock(stateMutex);
+    return cpu->isDecimalBugNMOS();
+}
+
 void EmulationController::setVramNoiseOnReset(bool enabled)
 {
     std::lock_guard<PriorityMutex> lock(stateMutex);

--- a/src/EmulationController.h
+++ b/src/EmulationController.h
@@ -144,6 +144,11 @@ public:
     void setPresetRamKB(int kb);
     void setSiliconStrictMode(bool enabled);
     bool isSiliconStrictMode() const;
+    // NMOS decimal-mode ADC/SBC flag bug (original Apple-1 6502) vs the 65C02
+    // "corrected" flags. Selectable in the Silicon window (strict = bug,
+    // fantasy = corrected). Forwards to M6502::setDecimalBugNMOS.
+    void setCpuDecimalBugNMOS(bool enabled);
+    bool isCpuDecimalBugNMOS() const;
     // Silicon fidelity profile knobs. Each takes effect on the next
     // hardReset (or Memory::resetMemory). Defaults are OFF — historic
     // POM1 behaviour (MSX1 bistable VRAM, zero-init RAM) is preserved.

--- a/src/M6502.cpp
+++ b/src/M6502.cpp
@@ -299,27 +299,35 @@ void M6502::ADC(void)
 
     if (statusRegister & M6502::Status::D)
     {
-        // Canonical NMOS 6502 decimal ADC (Bruce Clark, "Decimal mode in the
-        // 6502"). Correct for every input incl. invalid BCD nibbles and the
-        // "undocumented" N/V flags. Z is taken from the BINARY sum (NMOS quirk).
+        // Decimal ADC. The accumulator result follows the canonical NMOS
+        // algorithm (Bruce Clark) for every input incl. invalid BCD. The N/Z
+        // FLAGS depend on the selected mode:
+        //   decimalBugNMOS  -> original NMOS chip: Z from the binary sum, N from
+        //                      the pre-adjust intermediate (the documented bug).
+        //   !decimalBugNMOS -> 65C02 "corrected": N/Z reflect the BCD result.
         const int c = (statusRegister & M6502::Status::C) ? 1 : 0;
-        if (!((Op1 + Op2 + c) & 0xFF)) statusRegister |= M6502::Status::Z;
-        else                           statusRegister &= ~M6502::Status::Z;
-
         int al = (Op1 & 0x0F) + (Op2 & 0x0F) + c;
         if (al >= 0x0A) al = ((al + 0x06) & 0x0F) + 0x10;
         int a = (Op1 & 0xF0) + (Op2 & 0xF0) + al;   // high sum; may exceed 0xFF
 
-        // N/V come from the high-nibble sum BEFORE the final decimal adjust.
-        if (a & 0x80) statusRegister |= M6502::Status::N;
-        else          statusRegister &= ~M6502::Status::N;
+        // V (overflow) from the pre-adjust sum — same value in both modes.
         if ((~(Op1 ^ Op2)) & (Op1 ^ a) & 0x80) statusRegister |= M6502::Status::V;
         else                                    statusRegister &= ~M6502::Status::V;
 
+        const int preAdjust = a;
         if (a >= 0xA0) a += 0x60;
         if (a >= 0x100) statusRegister |= M6502::Status::C;
         else            statusRegister &= ~M6502::Status::C;
         accumulator = (uint8_t)(a & 0xFF);
+
+        if (decimalBugNMOS) {
+            if (!((Op1 + Op2 + c) & 0xFF)) statusRegister |= M6502::Status::Z;
+            else                            statusRegister &= ~M6502::Status::Z;
+            if (preAdjust & 0x80) statusRegister |= M6502::Status::N;
+            else                  statusRegister &= ~M6502::Status::N;
+        } else {
+            setStatusRegisterNZ(accumulator);
+        }
     }
     else
     {
@@ -365,8 +373,9 @@ uint8_t Op1 = accumulator, Op2 = memory->memRead(op);
         else                statusRegister &= ~M6502::Status::C;
         if (((Op1 ^ Op2) & (Op1 ^ bin)) & 0x80) statusRegister |= M6502::Status::V;
         else                                     statusRegister &= ~M6502::Status::V;
-        setStatusRegisterNZ((uint8_t)bin);
         accumulator = (uint8_t)(a & 0xFF);
+        // NMOS bug: N/Z from the binary result. 65C02 corrected: from the BCD result.
+        setStatusRegisterNZ(decimalBugNMOS ? (uint8_t)bin : accumulator);
     }
     else
     {

--- a/src/M6502.h
+++ b/src/M6502.h
@@ -113,6 +113,12 @@ public:
     void setYRegister(uint8_t v)      { yRegister = v; }
     void setStatusRegister(uint8_t v) { statusRegister = v; }
     void setStackPointer(uint8_t v)   { stackPointer = v; }
+    // NMOS decimal-mode ADC/SBC flag behaviour. true (default) = the original
+    // NMOS 6502 "bug" (N/Z invalid in decimal — real Apple-1 silicon); false =
+    // 65C02-style corrected flags (N/Z reflect the BCD result). Toggled from the
+    // Silicon window: silicon-strict = bug, fantasy = corrected.
+    void setDecimalBugNMOS(bool b) { decimalBugNMOS = b; }
+    bool isDecimalBugNMOS() const  { return decimalBugNMOS; }
 
     /// PC-matched halt for headless/scripted debugging. When `active` is
     /// true and `programCounter == address` at the top of `run()`'s loop,
@@ -168,6 +174,7 @@ private :
     uint16_t breakpointAddress  = 0;
 
     uint8_t accumulator, xRegister, yRegister, statusRegister, stackPointer;
+    bool decimalBugNMOS = true;   // NMOS decimal ADC/SBC flag bug (Silicon-window selectable)
     int IRQ, NMI;
     uint16_t programCounter;
     uint16_t op;

--- a/src/MainWindow_HardwareWindows.cpp
+++ b/src/MainWindow_HardwareWindows.cpp
@@ -2139,6 +2139,8 @@ void MainWindow_ImGui::renderSiliconStrictWindow()
             emulation->setSystemRamNoiseOnReset(turnOn);
             emulation->setDramRefreshEnabled(turnOn);
             emulation->setOutOfRangeStrictMode(turnOn);
+            cpuDecimalBugEnabled           = turnOn;
+            emulation->setCpuDecimalBugNMOS(turnOn);
             // Strict-mode RAM topology: real Apple-1 has 8 KB dual-bank RAM
             // ($0000-$0FFF + $E000-$EFFF) with $1000-$7FFF floating. Force
             // the preset RAM ceiling to 8 KB when strict is armed; restore
@@ -2172,6 +2174,7 @@ void MainWindow_ImGui::renderSiliconStrictWindow()
                 "   - Apple-1 RAM noise on cold boot / hard reset\n"
                 "   - Apple-1 DRAM refresh stall (4/65 cycle steal)\n"
                 "   - Out-of-range RAM strict (reads -> $FF, writes dropped)\n"
+                "   - 6502 NMOS decimal ADC/SBC flag bug\n"
                 "   - RAM ceiling: 8 KB dual-bank ($0000-$0FFF + $E000-$EFFF)\n"
                 "   - Parmigiani's one-board-at-a-time rule (auto-evict)\n\n"
                 "Silicon Strict  : every knob ON — POM1 behaves like real\n"
@@ -2295,6 +2298,38 @@ void MainWindow_ImGui::renderSiliconStrictWindow()
                 "(No effect at 64 KB preset — no OOR region.)");
             ImGui::PopStyleColor();
         }
+    }
+
+    // -------- 3b. MOS 6502 CPU (NMOS) -------------------------------------
+    if (ImGui::CollapsingHeader("MOS 6502 CPU (NMOS)",
+                                ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::SeparatorText("Decimal mode (ADC/SBC)");
+        bool decFlag = cpuDecimalBugEnabled;
+        if (ImGui::Checkbox("NMOS decimal ADC/SBC flag bug (original chip)##decbug",
+                            &decFlag)) {
+            cpuDecimalBugEnabled = decFlag;
+            emulation->setCpuDecimalBugNMOS(decFlag);
+            setStatusMessage(decFlag
+                ? "Decimal ADC/SBC: NMOS bug — N/Z invalid in decimal (real Apple-1 6502)"
+                : "Decimal ADC/SBC: corrected — N/Z reflect the BCD result (65C02-style)",
+                3.5f);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "The NMOS 6502 (the Apple-1's CPU) leaves N, V and Z *invalid*\n"
+                "after ADC/SBC in decimal (SED) mode — only the A result and the\n"
+                "carry are correct. The 65C02 later fixed this (valid N/Z, +1 cyc).\n\n"
+                "ON  (Silicon Strict) : reproduce the original NMOS flag bug — what\n"
+                "                       real Apple-1 silicon does.\n"
+                "OFF (Fantasy)        : corrected flags (N/Z from the BCD result).\n\n"
+                "Takes effect immediately. The A result and carry are identical in\n"
+                "both modes; only N/Z (and V) differ. No shipped Apple-1 software\n"
+                "uses decimal mode, so this is a fidelity nicety.");
+        }
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.7f, 0.7f, 1.0f));
+        ImGui::TextWrapped(
+            "Pinned by the Tom Harte oracle (cpu_harte_smoke) in NMOS mode.");
+        ImGui::PopStyleColor();
     }
 
     // -------- 4. TMS9918 Graphic Card -------------------------------------

--- a/src/MainWindow_ImGui.cpp
+++ b/src/MainWindow_ImGui.cpp
@@ -530,6 +530,8 @@ void MainWindow_ImGui::render()
             const bool v = *siliconStrictModeOverride;
             emulation->setSiliconStrictMode(v);
             siliconStrictModeEnabled = v;
+            emulation->setCpuDecimalBugNMOS(v);
+            cpuDecimalBugEnabled = v;
         }
         if (initialExecutionSpeed) {
             executionSpeed = *initialExecutionSpeed;

--- a/src/MainWindow_ImGui.h
+++ b/src/MainWindow_ImGui.h
@@ -290,6 +290,7 @@ private:
     // the Hardware menu toggle. Drives the Hardware menu checkbox state and
     // the STRICT/FANTASY status-bar tag.
     bool siliconStrictModeEnabled = true;
+    bool cpuDecimalBugEnabled = true;     // NMOS decimal ADC/SBC bug (Silicon window): strict=on, fantasy=off
     // Silicon Strict Inspector window — opens from the Hardware menu just
     // below the timing toggle. Surfaces drop-diagnostics live + lets the
     // user pick faithful silicon profile toggles (VRAM/RAM cold-boot noise).

--- a/src/MainWindow_Presets.cpp
+++ b/src/MainWindow_Presets.cpp
@@ -639,6 +639,10 @@ void MainWindow_ImGui::applyMachineConfig(int presetIndex)
     emulation->setSiliconStrictMode(!fantasyPreset);
     siliconStrictModeEnabled = !fantasyPreset;
     emulation->setOutOfRangeStrictMode(!fantasyPreset);
+    // NMOS decimal ADC/SBC flag bug: original-chip behaviour on strict presets,
+    // 65C02-corrected on the (fantasy) Multiplexing presets.
+    emulation->setCpuDecimalBugNMOS(!fantasyPreset);
+    cpuDecimalBugEnabled = !fantasyPreset;
 
     // UI flags reflect the preset's target state immediately (the menu
     // checkmarks and toolbar chips are driven by these). The actual

--- a/tests/cpu_interrupt_test.cpp
+++ b/tests/cpu_interrupt_test.cpp
@@ -28,7 +28,8 @@
 
 namespace {
 // 6502 status bits.
-constexpr uint8_t FLAG_C = 0x01, FLAG_I = 0x04, FLAG_B = 0x10, FLAG_U = 0x20, FLAG_N = 0x80;
+constexpr uint8_t FLAG_C = 0x01, FLAG_Z = 0x02, FLAG_I = 0x04, FLAG_D = 0x08,
+                  FLAG_B = 0x10, FLAG_U = 0x20, FLAG_N = 0x80;
 
 int g_oks = 0, g_fails = 0;
 void check(bool cond, const char* msg) {
@@ -116,6 +117,43 @@ int main() {
     check(cpu.getStatusRegister() == (uint8_t)((FLAG_N | FLAG_C | FLAG_U)), "RTI restored P (bit5 forced 1, bit4 0)");
     check(cpu.getCurrentInstructionCycles() == 6, "RTI = 6 cycles");
 
-    std::printf("CPU interrupt timing: %d checks passed, %d failed\n", g_oks, g_fails);
+    // ---- 6. Decimal ADC/SBC: NMOS bug vs corrected (Silicon-selectable) ----
+    // ADC $50+$50 (C=0, D): result $00 in both modes. NMOS -> N=1,Z=0 (N from
+    // pre-adjust intermediate, Z from binary sum); corrected -> N=0,Z=1 (BCD
+    // result). The A result + carry are identical; only N/Z differ.
+    cpu.setIRQ(0);
+    ram[0x0600] = 0x69; ram[0x0601] = 0x50;   // ADC #$50
+    for (int nmos = 1; nmos >= 0; --nmos) {
+        cpu.setDecimalBugNMOS(nmos != 0);
+        cpu.setProgramCounter(0x0600);
+        cpu.setAccumulator(0x50);
+        cpu.setStatusRegister(FLAG_U | FLAG_D);   // C = 0
+        cpu.step();
+        check(cpu.getAccumulator() == 0x00, "decimal ADC $50+$50 = $00 (both modes)");
+        if (nmos) {
+            check((cpu.getStatusRegister() & FLAG_N) == FLAG_N, "NMOS decimal ADC: N=1 (bug)");
+            check((cpu.getStatusRegister() & FLAG_Z) == 0,      "NMOS decimal ADC: Z=0 (bug)");
+        } else {
+            check((cpu.getStatusRegister() & FLAG_N) == 0,      "corrected decimal ADC: N=0");
+            check((cpu.getStatusRegister() & FLAG_Z) == FLAG_Z, "corrected decimal ADC: Z=1");
+        }
+    }
+    // SBC $00-$80 (C=1, D): result $20 in both modes. NMOS N=1 (from binary
+    // -128); corrected N=0 (from BCD result $20).
+    ram[0x0610] = 0xE9; ram[0x0611] = 0x80;   // SBC #$80
+    for (int nmos = 1; nmos >= 0; --nmos) {
+        cpu.setDecimalBugNMOS(nmos != 0);
+        cpu.setProgramCounter(0x0610);
+        cpu.setAccumulator(0x00);
+        cpu.setStatusRegister(FLAG_U | FLAG_D | FLAG_C);   // C = 1 (no borrow in)
+        cpu.step();
+        check(cpu.getAccumulator() == 0x20, "decimal SBC $00-$80 = $20 (both modes)");
+        if (nmos) check((cpu.getStatusRegister() & FLAG_N) == FLAG_N, "NMOS decimal SBC: N=1 (bug)");
+        else      check((cpu.getStatusRegister() & FLAG_N) == 0,      "corrected decimal SBC: N=0");
+    }
+    cpu.setDecimalBugNMOS(true);   // restore the NMOS default
+
+    std::printf("CPU interrupt + decimal-mode behaviour: %d checks passed, %d failed\n",
+                g_oks, g_fails);
     return g_fails == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Makes the decimal-mode `ADC`/`SBC` flag behavior **selectable** between the original NMOS 6502 bug and the 65C02-corrected variant, exposed in the Silicon Strict Inspector — silicon-strict = bug, fantasy = corrected.

## What

- **M6502** `decimalBugNMOS` flag (default **true** = NMOS). Decimal `ADC`/`SBC` keep the exact NMOS **result + carry** in both modes; only **N/Z** differ:
  - NMOS (bug): `ADC` Z from the binary sum, N from the pre-adjust intermediate; `SBC` N/Z from the binary result.
  - Corrected (65C02): N/Z reflect the final BCD result.
- **EmulationController** `setCpuDecimalBugNMOS` / `isCpuDecimalBugNMOS`.
- **Preset default**: strict presets → NMOS bug; (fantasy) Multiplexing presets → corrected (mirrors `siliconStrictModeEnabled = !fantasyPreset`).
- **Silicon Strict Inspector**: new "MOS 6502 CPU (NMOS)" section + checkbox; the master STRICT/FANTASY switch arms/disarms it with the other knobs; the `--silicon-strict` CLI override flips it too.
- **Test**: `cpu_interrupt_smoke` +10 decimal checks (NMOS vs corrected) for `ADC $50+$50` and `SBC $00-$80`.

## Verification

Default stays NMOS, so the Harte oracle (real-hardware reference) is unaffected: **cpu_harte 15100/15100**, **full ctest 32/32**, POM1 builds.

https://claude.ai/code/session_01WE1NNLXnprBryHeHTVm428

---
_Generated by [Claude Code](https://claude.ai/code/session_01WE1NNLXnprBryHeHTVm428)_